### PR TITLE
Add Travis status icon to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pyscal [![Build Status](https://travis-ci.org/equinor/pyscal.svg?branch=master)](https://travis-ci.org/equinor/pyscal)
+# pyscal [![Build Status](https://travis-ci.com/equinor/pyscal.svg?branch=master)](https://travis-ci.com/equinor/pyscal)
 
 Python module for relative permeability/SCAL support in reservoir simulation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pyscal
+# pyscal [![Build Status](https://travis-ci.org/equinor/pyscal.svg?branch=master)](https://travis-ci.org/equinor/pyscal)
 
 Python module for relative permeability/SCAL support in reservoir simulation
 


### PR DESCRIPTION
Add icon with link in the README header.

At first I added the wrong link (to the `.org`-travis), but corrected it in the second commit, so it would be good if the commits are squashed before merge.