### PR TITLE
kroend/kromax support for GasOil

### DIFF
--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -104,7 +104,7 @@ class GasOil(object):
         self.table.sort_values(by="sg", inplace=True)
         self.table.reset_index(inplace=True)
         self.table = self.table[["sg"]]
-        self.table["sl"] = 1 - self.table["sg"] - swl
+        self.table["sl"] = 1 - self.table["sg"]
         if krgendanchor == "sorg":
             # Normalized sg (sgn) is 0 at sgcr, and 1 at 1-swl-sorg
             self.table["sgn"] = (self.table["sg"] - sgcr) / (1 - swl - sgcr - sorg)
@@ -112,7 +112,7 @@ class GasOil(object):
             self.table["sgn"] = (self.table["sg"] - sgcr) / (1 - swl - sgcr)
 
         # Normalized oil saturation should be 0 at 1-sorg, and 1 at swl+sgcr
-        self.table["son"] = (self.table["sl"] - sorg) / (1 - sorg - swl - sgcr)
+        self.table["son"] = (self.table["sl"] - sorg - swl) / (1 - sorg - swl - sgcr)
         self.sgcomment = (
             '-- swirr=%g, sgcr=%g, swl=%g, sorg=%g, krgendanchor="%s"\n'
             % (self.swirr, self.sgcr, self.swl, self.sorg, self.krgendanchor)

--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -260,12 +260,18 @@ class GasOil(object):
         self.table["krog"] = kroend * self.table.son ** nog
 
         # Special handling of the part close to sg=1, set to zero.
-        self.table.loc[self.table["sg"] > 1 - self.sorg - self.swl - epsilon, "krog"] = 0
+        self.table.loc[
+            self.table["sg"] > 1 - self.sorg - self.swl - epsilon, "krog"
+        ] = 0
 
         # Set kromax at sg=0
         self.table.loc[self.table["sg"] < epsilon, "krog"] = kromax
 
-        self.krogcomment = "-- Corey krog, nog=%g, kroend=%g, kromax=%g\n" % (nog, kroend, kromax)
+        self.krogcomment = "-- Corey krog, nog=%g, kroend=%g, kromax=%g\n" % (
+            nog,
+            kroend,
+            kromax,
+        )
 
     def add_LET_gas(self, l=2, e=2, t=2, krgend=1, krgmax=None):
         """
@@ -354,10 +360,12 @@ class GasOil(object):
             / ((self.table["son"] ** l) + e * (1 - self.table["son"]) ** t)
         )
         # Special handling of the part close to sg=1, set to zero.
-        self.table.loc[self.table["sg"] > 1 - self.sorg - self.swl - epsilon, "krog"] = 0
+        self.table.loc[
+            self.table["sg"] > 1 - self.sorg - self.swl - epsilon, "krog"
+        ] = 0
 
         # Set kromax at sg=0
-        self.table.loc[self.table['sg'] < epsilon, 'krog'] = kromax
+        self.table.loc[self.table["sg"] < epsilon, "krog"] = kromax
         self.krogcomment = "-- LET krog, l=%g, e=%g, t=%g, kroend=%g, kromax=%g\n" % (
             l,
             e,

--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -261,11 +261,8 @@ class GasOil(object):
         Returns:
             None (modifies internal class state)
         """
-        assert nog > epsilon
-        assert nog < MAX_EXPONENT
-        assert kroend > 0
-        assert kromax > 0
-        assert kroend <= kromax
+        assert epsilon < nog < MAX_EXPONENT
+        assert 0 < kroend <= kromax
 
         self.table["krog"] = kroend * self.table.son ** nog
 
@@ -364,14 +361,10 @@ class GasOil(object):
             kroend (float): The value at gas saturation sgcr
             kromax (float): The value at gas saturation equal to 1.
         """
-        assert l > epsilon
-        assert l < MAX_EXPONENT
-        assert e > epsilon
-        assert e < MAX_EXPONENT
-        assert t > epsilon
-        assert t < MAX_EXPONENT
-        assert kroend > 0
-        assert kromax > 0
+        assert epsilon < l < MAX_EXPONENT
+        assert epsilon < e < MAX_EXPONENT
+        assert epsilon < t < MAX_EXPONENT
+        assert 0 < kroend <= kromax
 
         # LET shape for the interval [sgcr, 1 - swl - sorg]
         self.table["krog"] = (

--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -248,14 +248,24 @@ class GasOil(object):
         """
         Add kro data through the Corey parametrization
 
-        A column named 'kro' will be added, replaced if it exists.
+        A column named 'kro' will be added to the internal DataFrame,
+        replaced if it exists.
 
         All values above 1 - sorg - swl are set to zero.
+
+        Arguments:
+            nog (float): Corey exponent for oil
+            kroend (float): Value for krog at normalized oil saturation 1
+            kromax (float): Value for krog at gas saturation 0.
+
+        Returns:
+            None (modifies internal class state)
         """
         assert nog > epsilon
         assert nog < MAX_EXPONENT
         assert kroend > 0
         assert kromax > 0
+        assert kroend <= kromax
 
         self.table["krog"] = kroend * self.table.son ** nog
 
@@ -282,6 +292,16 @@ class GasOil(object):
         If krgendanchor is set to `sorg` (default), then the normalized
         gas saturation `sgn` (which is what is raised to the power of `ng`)
         is 1 at `1 - swl - sgcr - sorg`. If not, it is 1 at `1 - swl - sgcr`
+
+        Arguments:
+            l (float): L parameter in LET
+            e (float): E parameter in LET
+            t (float): T parameter in LET
+            krgend (float): Value of krg at normalized gas saturation 1
+            krgmax (float): Value of krg at gas saturation 1
+
+        Returns:
+            None (modifies internal state)
         """
         assert l > epsilon
         assert l < MAX_EXPONENT

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -112,6 +112,19 @@ def test_gasoil_krgendanchor():
     assert gasoil.table[np.isclose(gasoil.table["sg"], 1.0)]["krg"].values[0] == 1.0
 
 
+def test_kromaxend():
+    gasoil = GasOil(swirr=0.01, sgcr=0.01, h=0.01, swl=0.1, sorg=0.05)
+    gasoil.add_LET_gas()
+    gasoil.add_LET_oil(2, 2, 2)
+    assert gasoil.table["krog"].max() == 1
+    gasoil.add_LET_oil(2, 2, 2, 0.5, 0.9)
+    assert gasoil.table["krog"].max() == 0.9
+
+    # Second krog-value should be kroend, values in between will be linearly
+    # interpolated in Eclipse
+    assert gasoil.table.sort_values("krog")[-2:-1]["krog"].values[0] == 0.5
+
+
 @settings(deadline=1000)
 @given(st.floats(), st.floats())
 def test_gasoil_corey1(ng, nog):

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -113,15 +113,21 @@ def test_gasoil_krgendanchor():
 
 
 def test_kromaxend():
+    """Manual testing of kromax and kroend behaviour"""
     gasoil = GasOil(swirr=0.01, sgcr=0.01, h=0.01, swl=0.1, sorg=0.05)
     gasoil.add_LET_gas()
     gasoil.add_LET_oil(2, 2, 2)
     assert gasoil.table["krog"].max() == 1
     gasoil.add_LET_oil(2, 2, 2, 0.5, 0.9)
     assert gasoil.table["krog"].max() == 0.9
-
     # Second krog-value should be kroend, values in between will be linearly
     # interpolated in Eclipse
+    assert gasoil.table.sort_values("krog")[-2:-1]["krog"].values[0] == 0.5
+
+    gasoil.add_corey_oil(2)
+    assert gasoil.table["krog"].max() == 1
+    gasoil.add_corey_oil(2, 0.5, 0.9)
+    assert gasoil.table["krog"].max() == 0.9
     assert gasoil.table.sort_values("krog")[-2:-1]["krog"].values[0] == 0.5
 
 

--- a/tests/test_slgof.py
+++ b/tests/test_slgof.py
@@ -11,7 +11,7 @@ import hypothesis.strategies as st
 import numpy as np
 
 from pyscal import WaterOilGas, GasOil
-from pyscal.constants import SWINTEGERS
+from pyscal.constants import SWINTEGERS, EPSILON
 
 
 def check_table(df):
@@ -22,7 +22,8 @@ def check_table(df):
     assert df["sl"].is_monotonic
     assert (df["sl"] >= 0.0).all()
     assert (df["sl"] <= 1.0).all()
-    assert df["krog"].is_monotonic_increasing
+    # Increasing, but not monotonically for slgof
+    assert (df["krog"].diff().dropna() > -EPSILON).all()
     assert df["krg"].is_monotonic_decreasing
     if "pc" in df:
         assert df["pc"].is_monotonic_decreasing

--- a/tests/test_wateroil.py
+++ b/tests/test_wateroil.py
@@ -11,7 +11,6 @@ import hypothesis.strategies as st
 from pyscal import WaterOil
 
 
-
 def check_table(df):
     """Check sanity of important columns"""
     assert not df.empty


### PR DESCRIPTION
Fix/support kroend and kromax for GasOil objects.

This was fixed in the original repository, but porting over to pyscal must have used outdated source code. 