### PR TITLE
Utilize six to test for strings for both py2 and py3

### DIFF
--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import logging
 import numpy as np
 import pandas as pd
+import six
 
 from pyscal import utils
 
@@ -62,9 +63,9 @@ class GasOil(object):
         assert -epsilon < sgcr < 1
         assert -epsilon < swl < 1
         assert -epsilon < sorg < 1
-        if not isinstance(tag, str):
+        if not isinstance(tag, six.string_types):
             tag = ""
-        assert isinstance(krgendanchor, str)
+        assert isinstance(krgendanchor, six.string_types)
 
         self.h = h
         swl = max(swl, swirr)  # Can't allow swl < swirr, should we warn user?

--- a/pyscal/utils.py
+++ b/pyscal/utils.py
@@ -1,6 +1,7 @@
 """Utility function for pyscal
 """
 import pandas as pd
+import six
 
 from pyscal.constants import SWINTEGERS
 from pyscal.constants import EPSILON as epsilon
@@ -115,8 +116,8 @@ def estimate_diffjumppoint(table, xcol=None, ycol=None, side="right"):
         xcol = table.columns[0]
     if not ycol:
         ycol = table.columns[1]
-    assert isinstance(ycol, str)
-    assert isinstance(xcol, str)
+    assert isinstance(ycol, six.string_types)
+    assert isinstance(xcol, six.string_types)
     if not side:
         raise ValueError("side cannot be None, use left or right")
     side = side.lower()

--- a/pyscal/wateroil.py
+++ b/pyscal/wateroil.py
@@ -6,6 +6,7 @@ import math
 import logging
 import numpy as np
 import pandas as pd
+import six
 
 from pyscal.constants import EPSILON as epsilon
 from pyscal.constants import SWINTEGERS
@@ -47,7 +48,7 @@ class WaterOil(object):
         assert swl < 1 - sorw
         assert swcr < 1 - sorw
         assert swirr < 1 - sorw
-        if not isinstance(tag, str):
+        if not isinstance(tag, six.string_types):
             tag = ""
         self.swirr = swirr
         self.swl = max(swl, swirr)  # Cannot allow swl < swirr. Warn?

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 numpy
 scipy
+six

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ scipy
 sphinx
 sphinx_rtd_theme
 xlrd
+six


### PR DESCRIPTION
Current code will crash on Python 2 if a unicode strings is sent in,
due to an assert.