### PR TITLE
Print-bug for capillary pressure, utf-8/unicode

### DIFF
--- a/pyscal/wateroil.py
+++ b/pyscal/wateroil.py
@@ -765,7 +765,7 @@ class WaterOil(object):
         self.table.loc[self.table["swn"] < epsilon, "pc"] = Pcmax
         self.pccomment = (
             "-- LET correlation for primary drainage Pc;\n"
-            + "-- Lp=%g, Ep=%g, Tp=%g, Lt=%g, Et=%g, Tt=%g, Pcmax=%g, Pct=%g\n"
+            "-- Lp=%g, Ep=%g, Tp=%g, Lt=%g, Et=%g, Tt=%g, Pcmax=%g, Pct=%g\n"
             % (Lp, Ep, Tp, Lt, Et, Tt, Pcmax, Pct)
         )
 
@@ -809,8 +809,8 @@ class WaterOil(object):
         # and [1-sorw,1]
         self.table.loc[self.table["swnpco"] > 1 - epsilon, "pc"] = Pcmin
         self.pccomment = (
-            "-- LET correlation for imbibition Pc;\n -- "
-            + "Ls=%g, Es=%g, Ts=%g, Lf=%g, Ef=%g, Tf=%g, Pcmax=%g, Pcmin=%g, Pct=%g\n"
+            "-- LET correlation for imbibition Pc;\n"
+            "-- Ls=%g, Es=%g, Ts=%g, Lf=%g, Ef=%g, Tf=%g, Pcmax=%g, Pcmin=%g, Pct=%g\n"
             % (Ls, Es, Ts, Lf, Ef, Tf, Pcmax, Pcmin, Pct)
         )
 

--- a/pyscal/wateroil.py
+++ b/pyscal/wateroil.py
@@ -585,7 +585,7 @@ class WaterOil(object):
         self.table["pc"] = self.table.H * drho / 1000 * g / 100.0
         self.pccomment = (
             "-- Simplified J function for Pc; \n--   "
-            + "a=%g, b=%g, poro_ref=%g, perm_ref=%g mD, drho=%g kg/m³, g=%g m/s²\n"
+            + "a=%g, b=%g, poro_ref=%g, perm_ref=%g mD, drho=%g kg/m^3, g=%g m/s^2\n"
             % (a, b, poro_ref, perm_ref, drho, g)
         )
 

--- a/tests/test_wateroil_pc.py
+++ b/tests/test_wateroil_pc.py
@@ -14,7 +14,7 @@ import hypothesis.strategies as st
 from pyscal import WaterOil
 from pyscal.constants import MAX_EXPONENT
 
-from common import float_df_checker, check_table
+from common import float_df_checker, check_table, sat_table_str_ok
 
 
 def test_simple_j():
@@ -45,6 +45,8 @@ def test_simple_j():
     swof = wateroil.SWOF()
     assert isinstance(swof, str)
     assert swof
+    assert sat_table_str_ok(swof)
+    assert sat_table_str_ok(wateroil.SWFN())
 
 
 @given(
@@ -113,6 +115,9 @@ def test_norm_j_pc_random(swirr, swl, a_pc, b_pc, poro, perm, sigma_costau):
     except (AssertionError, ValueError):  # when poro is < 0 f.ex.
         return
     check_table(wateroil.table)
+    wateroil.add_corey_water()
+    wateroil.add_corey_oil()
+    assert sat_table_str_ok(wateroil.SWOF())
 
 
 def test_let_pc_pd():
@@ -138,7 +143,9 @@ def test_let_pc_pd():
         len(wateroil.table[(wateroil.table["sw"] >= 0.6) & (wateroil.table["sw"] <= 1)])
         == 2
     )
-    # wateroil.plotpc()
+    wateroil.add_corey_water()
+    wateroil.add_corey_oil()
+    assert sat_table_str_ok(wateroil.SWOF())
 
 
 def test_let_pc_imb():
@@ -159,3 +166,8 @@ def test_let_pc_imb():
     wateroil.add_LET_pc_imb(Ls=5, Es=5, Ts=5, Lf=5, Ef=5, Tf=5, Pcmax=5, Pcmin=1, Pct=4)
     assert np.isclose(wateroil.table["pc"].max(), 5)
     assert np.isclose(wateroil.table["pc"].min(), 1)
+    wateroil.add_corey_water()
+    wateroil.add_corey_oil()
+    print(wateroil.SWOF())
+
+    assert sat_table_str_ok(wateroil.SWOF())


### PR DESCRIPTION
Non-ascii in the strings are just too dangeous when py2 compatibility is needed, so give up.

Also resolve cosmetic whitespace issue with LET pc.