### PR TITLE
Setupfix

### DIFF
--- a/pyscal/__init__.py
+++ b/pyscal/__init__.py
@@ -18,5 +18,5 @@ try:
     from .version import version
     __version__ = version
 except ImportError:
-    __version__ =  "v0.0.0"
+    __version__ =  "0.0.0"
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     author="Håvard Berland",
     author_email="havb@equinor.com",
     license="LGPLv3",
-    packages=find_packages("pyscal"),
+    packages=["pyscal"],
     zip_safe=False,
     test_suite="tests",
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
Bug found by help of https://stackoverflow.com/questions/50585246/pip-install-creates-only-the-dist-info-not-the-package/54357929