### PR TITLE
Refactor and improve monotonocity handling in utils

### DIFF
--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -698,7 +698,7 @@ class GasOil(object):
             return ""
         string = ""
         if "pc" not in self.table:
-            self.table["pc"] = 0
+            self.table["pc"] = 0.0
             self.pccomment = "-- Zero capillary pressure\n"
         if header:
             string += "SGOF\n"
@@ -721,9 +721,7 @@ class GasOil(object):
             + "\n"
         )
         string += utils.df2str(
-            self.table[["sg", "krg", "krog", "pc"]],
-            monotone_column="pc",
-            monotone_direction="inc",
+            self.table[["sg", "krg", "krog", "pc"]], monotonocity={"pc": {"sign": 1}}
         )
         string += "/\n"
         return string
@@ -735,7 +733,7 @@ class GasOil(object):
         extracted as a single function to facilitate testing."""
         if "pc" not in self.table.columns:
             # Only happens when the SLGOF function is skipped (test code)
-            self.table["pc"] = 0
+            self.table["pc"] = 0.0
         slgof = (
             self.table[
                 self.table["sg"] <= 1 - self.sorg - self.swl + 1.0 / float(SWINTEGERS)
@@ -790,7 +788,7 @@ class GasOil(object):
             return ""
         string = ""
         if "pc" not in self.table:
-            self.table["pc"] = 0
+            self.table["pc"] = 0.0
             self.pccomment = "-- Zero capillary pressure\n"
         if header:
             string += "SLGOF\n"
@@ -811,9 +809,7 @@ class GasOil(object):
             + "PC".ljust(width)
             + "\n"
         )
-        string += utils.df2str(
-            self.slgof_df(), monotone_column="pc", monotone_direction="dec"
-        )
+        string += utils.df2str(self.slgof_df(), monotonocity={"pc": {"sign": -1}})
         string += "/\n"
         return string
 
@@ -845,7 +841,7 @@ class GasOil(object):
         """
         string = ""
         if "pc" not in self.table.columns:
-            self.table["pc"] = 0
+            self.table["pc"] = 0.0
             self.pccomment = "-- Zero capillary pressure\n"
         if header:
             string += "SGFN\n"
@@ -872,9 +868,7 @@ class GasOil(object):
             + "\n"
         )
         string += utils.df2str(
-            self.table[["sg", "krg", "pc"]],
-            monotone_column="pc",
-            monotone_direction="inc",
+            self.table[["sg", "krg", "pc"]], monotonocity={"pc": {"sign": 1}}
         )
         string += "/\n"
         return string
@@ -899,7 +893,7 @@ class GasOil(object):
         """
         string = ""
         if "pc" not in self.table.columns:
-            self.table["pc"] = 0
+            self.table["pc"] = 0.0
             self.pccomment = "-- Zero capillary pressure\n"
         if header:
             string += "GOTABLE\n"

--- a/pyscal/wateroil.py
+++ b/pyscal/wateroil.py
@@ -1100,7 +1100,7 @@ class WaterOil(object):
         string += utils.comment_formatter(self.tag)
         string += "-- pyscal: " + str(pyscal.__version__) + "\n"
         if "pc" not in self.table.columns:
-            self.table["pc"] = 0
+            self.table["pc"] = 0.0
             self.pccomment = "-- Zero capillary pressure\n"
         if dataincommentrow:
             string += self.swcomment
@@ -1119,9 +1119,7 @@ class WaterOil(object):
             + "\n"
         )
         string += utils.df2str(
-            self.table[["sw", "krw", "krow", "pc"]],
-            monotone_column="pc",
-            monotone_direction="dec",
+            self.table[["sw", "krw", "krow", "pc"]], monotonocity={"pc": {"sign": -1}}
         )
         string += "/\n"  # Empty line at the end
         return string
@@ -1155,7 +1153,7 @@ class WaterOil(object):
             return ""
         string = ""
         if "pc" not in self.table.columns:
-            self.table["pc"] = 0
+            self.table["pc"] = 0.0
             self.pccomment = "-- Zero capillary pressure\n"
         if header:
             string += "SWFN\n"
@@ -1182,9 +1180,7 @@ class WaterOil(object):
             + "\n"
         )
         string += utils.df2str(
-            self.table[["sw", "krw", "pc"]],
-            monotone_column="pc",
-            monotone_direction="dec",
+            self.table[["sw", "krw", "pc"]], monotonocity={"pc": {"sign": -1}}
         )
         string += "/\n"  # Empty line at the end
         return string
@@ -1193,7 +1189,7 @@ class WaterOil(object):
         """Return a string for a Nexus WOTABLE"""
         string = ""
         if "pc" not in self.table.columns:
-            self.table["pc"] = 0
+            self.table["pc"] = 0.0
             self.pccomment = "-- Zero capillary pressure\n"
 
         if header:
@@ -1217,9 +1213,7 @@ class WaterOil(object):
             + "\n"
         )
         string += utils.df2str(
-            self.table[["sw", "krw", "krow", "pc"]],
-            monotone_column="pc",
-            monotone_direction="dec",
+            self.table[["sw", "krw", "krow", "pc"]], monotonocity={"pc": {"sign": -1}}
         )
         return string
 


### PR DESCRIPTION
This makes it possible to activate monotonicity enforcing in relperm columns (not only pc).

Also ensure zero pc is floating point in Wateroil and GasOil, improves speed