### PR TITLE
Cleanup testing/error handling

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         pip install pip -U
         pip install .[tests]
+        pip install opm  # (extra package for more tests)
 
     - name: Generate coverage report
       run: |

--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -1,6 +1,7 @@
-""" Representing a GasOil object """
+"""Representing a GasOil object"""
 
 import logging
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -69,16 +70,20 @@ class GasOil(object):
     ):
         if h is None:
             h = 0.01
-        assert -epsilon < swirr < 1.0 + epsilon
-        assert -epsilon < sgcr < 1
-        assert -epsilon < swl < 1
-        assert -epsilon < sorg < 1
+        assert -epsilon < swirr < 1.0 + epsilon, "0 <= swirr <= 1 is required"
+        assert -epsilon < sgcr < 1, "0 <= sgcr < 1 is required"
+        assert -epsilon < swl < 1, "0 <= swl < 1 is required"
+        assert -epsilon < sorg < 1, "0 <= sorg <  1 is required"
         if not isinstance(tag, str):
+            warnings.warn(
+                "tag must be a string, this will be a hard failure later",
+                DeprecationWarning,
+            )
             tag = ""
         if krgendanchor is None:
             krgendanchor = ""
 
-        assert isinstance(krgendanchor, str)
+        assert isinstance(krgendanchor, str), "krgendanchor must be a string"
 
         h_min = 1.0 / float(SWINTEGERS)
         if h < h_min:
@@ -102,7 +107,7 @@ class GasOil(object):
         self.tag = tag
 
         if not 1 - sorg - swl > 0:
-            raise Exception(
+            raise ValueError(
                 "No saturation range left " + "after endpoints, check input"
             )
         if krgendanchor in ["sorg", ""]:

--- a/pyscal/utils/relperm.py
+++ b/pyscal/utils/relperm.py
@@ -107,24 +107,3 @@ def estimate_diffjumppoint(table, xcol=None, ycol=None, side="right"):
     if len(linearpart) == 1:
         linearpart = table[(table["_lindevcumsum"].shift(1) < epsilon)]
     return linearpart.iloc[-1][xcol]
-
-
-def comment_formatter(multiline, prefix="-- "):
-    """Prepends comment characters to every line in input
-
-    Args:
-        multiline (str): String that can contain newlines
-        prefix (str): Comment characters to prepend every line with
-            Default is the Eclipse comment syntax '-- '
-
-    Returns:
-        string, with newlines preserved, and where each line
-            starts with the given prefix. Always ends with a newline.
-    """
-    if multiline is None or not multiline.strip():
-        # Ensure we indicate that there is placeholder for something.
-        return "-- \n"
-    return (
-        "\n".join([prefix + line.strip() for line in multiline.splitlines()]).strip()
-        + "\n"
-    )

--- a/pyscal/wateroil.py
+++ b/pyscal/wateroil.py
@@ -805,7 +805,7 @@ class WaterOil(object):
         Returns false if error occured.
 
         """  # noqa
-        inputerror = False
+        inputerror = False  # Flag to be able to catch all errors
         if cw < 0:
             logger.error("cw must be larger or equal to zero")
             inputerror = True

--- a/tests/test_slgof.py
+++ b/tests/test_slgof.py
@@ -5,6 +5,8 @@ import hypothesis.strategies as st
 
 import numpy as np
 
+import pytest
+
 from pyscal import WaterOilGas, GasOil
 from pyscal.constants import SWINTEGERS, EPSILON
 
@@ -56,13 +58,21 @@ def test_slgof(swl, sorg, sgcr):
     assert np.isclose(slgof["krog"].values[0], 0)
 
 
-def test_gasoil_slgof():
-    """Test fine-tuned numerics for slgof"""
+@pytest.mark.parametrize(
+    "swl, sorg, sgcr",
+    [
+        # Parameter combinations exposed by pytest.hypothesis:
+        (0.029950000000000105, 0.0, 0.01994999999999992),
+        (0.285053445121882, 0.24900257734119435, 0.1660017182274629),
+    ],
+)
+def test_numerical_problems(swl, sorg, sgcr):
+    """Test fine-tuned numerics for slgof, this function should
+    trigger the code path in slgof_df() where slgof_sl_mismatch is small.
 
-    # Parameter set found by hypothesis
-    swl = 0.029950000000000105
-    sorg = 0.0
-    sgcr = 0.01994999999999992
+    Note: The code path taken may depend on hardware/OS etc.
+    """
+
     # Because we cut away some saturation points due to SWINTEGERS, we easily
     # end in a situation where the wrong saturation point of to "equal" ones
     # is removed (because in SLGOF, sg is flipped to sl)

--- a/tests/test_wateroilgas.py
+++ b/tests/test_wateroilgas.py
@@ -1,17 +1,78 @@
 """Test module for the WaterOilGas object"""
 
+from pathlib import Path
+
+import pytest
+
 from pyscal import WaterOilGas, WaterOil, GasOil
+from pyscal.utils.testing import sat_table_str_ok
+
+try:
+    import opm.io
+
+    HAVE_OPM = True
+except ImportError:
+    HAVE_OPM = False
+
+
+def test_wateroilgas_constructor():
+    """Test that constructor properties are available as aattributes"""
+    wog = WaterOilGas(swirr=0.01, swl=0.02, sorg=0.03, sorw=0.04, tag="Foo")
+    assert wog.swirr == 0.01
+    assert wog.swl == 0.02
+    assert wog.sorg == 0.03
+    assert wog.tag == "Foo"
+    assert wog.sorw == 0.04
+
+    # Manipulate the tag in the underlying GasOil object:
+    wog.gasoil.tag = "Bar"
+    assert wog.tag == "Foo Bar"  # Different tags are concatenated.
+
+
+def test_wateroilgas_simple():
+    """Test that default curves will give valid include strings"""
+    wog = WaterOilGas()
+
+    # Add default curves:
+    wog.wateroil.add_corey_water()
+    wog.wateroil.add_corey_oil()
+    wog.gasoil.add_corey_gas()
+    wog.gasoil.add_corey_oil()
+
+    with pytest.raises(AssertionError):
+        # Testing test code:
+        sat_table_str_ok("")
+    sat_table_str_ok(wog.SWOF())
+    sat_table_str_ok(wog.SGOF())
+    sat_table_str_ok(wog.SLGOF())
+    sat_table_str_ok(wog.SOF3())
+    sat_table_str_ok(wog.SGFN())
+    sat_table_str_ok(wog.SWFN())
 
 
 def test_threephasecheck():
     """Test three phase consistency checks"""
     wog = WaterOilGas()
+    assert not wog.selfcheck()
     wog.wateroil.add_corey_water(nw=2)
     wog.wateroil.add_corey_oil(now=2, kroend=0.9)
     wog.gasoil.add_corey_gas(ng=2)
     wog.gasoil.add_corey_oil(nog=2, kroend=1)
     assert not wog.threephaseconsistency()
 
+
+def test_empty():
+    """Empty object should give empty strings (and logged errors)"""
+    wog = WaterOilGas()
+    assert wog.SWOF() == ""
+    assert wog.SGOF() == ""
+    assert wog.SOF3() == ""
+    assert wog.SLGOF() == ""
+    assert wog.SWFN() == ""
+    assert wog.SGFN() == ""
+
+
+def test_not_threephase_consistency():
     wog = WaterOilGas()
     # To trigger this, we need to hack the WaterOilGas object
     # by overriding the effect of its __init__
@@ -22,3 +83,74 @@ def test_threephasecheck():
     wog.gasoil.add_corey_gas(ng=2)
     wog.gasoil.add_corey_oil(nog=2, kroend=1)
     assert not wog.threephaseconsistency()
+
+
+@pytest.mark.skipif(not HAVE_OPM, reason="ecl2df not installed")
+def test_parse_with_opm(tmpdir):
+    """Test that the SWOF+SGOF output from pyscal can be
+    injected into a valid Eclipse deck"""
+    wog = WaterOilGas()
+    wog.wateroil.add_corey_water(nw=2)
+    wog.wateroil.add_corey_oil(now=2, kroend=0.9)
+    wog.gasoil.add_corey_gas(ng=2)
+    wog.gasoil.add_corey_oil(nog=2, kroend=1)
+
+    ecldeck = (
+        """RUNSPEC
+DIMENS
+  1 1 1 /
+OIL
+WATER
+GAS
+START
+  1 'JAN' 2100 /
+TABDIMS
+   2* 10000 /
+EQLDIMS
+  1 /
+GRID
+DX
+   10 /
+DY
+   10 /
+DZ
+   50 /
+TOPS
+   1000 /
+PORO
+   0.3 /
+PERMX
+   100 /
+PERMY
+   100 /
+PERMZ
+   100 /
+
+PROPS
+
+"""
+        + wog.SWOF()
+        + wog.SGOF()
+        + """
+DENSITY
+  800 1000 1.2 /
+PVTW
+  1 1 0.0001 0.2 0.00001 /
+PVDO
+   100 1   1
+   150 0.9 1 /
+PVDG
+   100 1 1
+   150 0.9 1 /
+ROCK
+  100 0.0001 /
+SOLUTION
+EQUIL
+   1000    100     1040    0   1010      0 /"""
+    )
+
+    tmpdir.chdir()
+    Path("RELPERMTEST.DATA").write_text(ecldeck)
+    deck = opm.io.Parser().parse("RELPERMTEST.DATA")
+    assert "SWOF" in deck
+    assert "SGOF" in deck


### PR DESCRIPTION
* Very minor changes to handling of error conditions
* Removed run_eclipse_test (non-functional) from API, moved to test code
  using OPM.
* Add test code for non-triggered code paths
* Removed duplicated utils/relperm.py::comment_formatter