### PR TITLE
Change internal dataframe column names to upper case

### DIFF
--- a/pyscal/gaswater.py
+++ b/pyscal/gaswater.py
@@ -245,22 +245,22 @@ class GasWater(object):
             float: the gas saturation where krw == krg, for relperm
                 linearly interpolated in water saturation.
         """
-        if not {"sw", "krw"}.issubset(self.wateroil.table.columns):
-            logger.warning("Can't compute crosspoint when krw is not present")
+        if not {"SW", "KRW"}.issubset(self.wateroil.table.columns):
+            logger.warning("Can't compute crosspoint when KRW is not present")
             return None
-        if not {"sl", "krg"}.issubset(self.gasoil.table.columns):
-            logger.warning("Can't compute crosspoint when krg is not present")
+        if not {"SL", "KRG"}.issubset(self.gasoil.table.columns):
+            logger.warning("Can't compute crosspoint when KRG is not present")
             return None
         dframe = pd.concat(
-            [self.wateroil.table[["sw", "krw"]], self.gasoil.table[["sl", "krg"]]],
+            [self.wateroil.table[["SW", "KRW"]], self.gasoil.table[["SL", "KRG"]]],
             sort=False,
         )
-        # The  "sl" column in the GasOil object corresponds exactly to "sw" in WaterOil
+        # The  "SL" column in the GasOil object corresponds exactly to "SW" in WaterOil
         # but since they are floating point, we do not want to "merge" dataframes on it,
         # rather concatenate and let linear interpolation fill in values.
-        dframe["sw"].fillna(value=0, inplace=True)
-        dframe["sl"].fillna(value=0, inplace=True)
-        dframe["sat"] = dframe["sl"] + dframe["sw"]
+        dframe["SW"].fillna(value=0, inplace=True)
+        dframe["SL"].fillna(value=0, inplace=True)
+        dframe["sat"] = dframe["SL"] + dframe["SW"]
         dframe = (
             dframe.set_index("sat")
             .sort_index()
@@ -268,7 +268,7 @@ class GasWater(object):
             .dropna()
             .reset_index()
         )
-        return crosspoint(dframe, "sat", "krw", "krg")
+        return crosspoint(dframe, "sat", "KRW", "KRG")
 
     def plotkrwkrg(
         self,
@@ -302,8 +302,8 @@ class GasWater(object):
             useax.set_ylim([1e-8, 1])
         self.wateroil.table.plot(
             ax=useax,
-            x="sw",
-            y="krw",
+            x="SW",
+            y="KRW",
             c=color,
             alpha=alpha,
             legend=None,
@@ -314,8 +314,8 @@ class GasWater(object):
         )
         self.gasoil.table.plot(
             ax=useax,
-            x="sl",
-            y="krg",
+            x="SL",
+            y="KRG",
             c=color,
             alpha=alpha,
             label=None,
@@ -324,7 +324,7 @@ class GasWater(object):
             linestyle=linestyle,
             marker=marker,
         )
-        plt.xlabel("sw")
+        plt.xlabel("SW")
         if mpl_ax is None:
             plt.show()
 

--- a/pyscal/pyscallist.py
+++ b/pyscal/pyscallist.py
@@ -78,12 +78,12 @@ class PyscalList(object):
             pd.DataFrame
         """
         # Names of dataframe columns in wateroil/gasoil.table:
-        wateroil_pyscal_cols = {"sw", "krw", "krow", "pc"}
-        gasoil_pyscal_cols = {"sg", "krg", "krog", "pc"}
+        wateroil_pyscal_cols = {"SW", "KRW", "KROW", "PC"}
+        gasoil_pyscal_cols = {"SG", "KRG", "KROG", "PC"}
 
         # Renamers applied to the returned dataframe:
-        gasoil_col_renamer = {"sg": "SG", "krg": "KRG", "krog": "KROG", "pc": "PCOG"}
-        wateroil_col_renamer = {"sw": "SW", "krw": "KRW", "krow": "KROW", "pc": "PCOW"}
+        gasoil_col_renamer = {"SG": "SG", "KRG": "KRG", "KROG": "KROG", "PC": "PCOG"}
+        wateroil_col_renamer = {"SW": "SW", "KRW": "KRW", "KROW": "KROW", "PC": "PCOW"}
 
         # Sort order for rows in returned dataframe:
         sort_candidates = ["SATNUM", "CASE", "KEYWORD", "SW", "SG", "SL"]

--- a/pyscal/utils/interpolation.py
+++ b/pyscal/utils/interpolation.py
@@ -37,11 +37,11 @@ def normalize_nonlinpart_wo(curve):
             evaluate krow on the normalized So interval [0,1].
     """
     krw_interp = interp1d(
-        curve.table["sw"],
-        curve.table["krw"],
+        curve.table["SW"],
+        curve.table["KRW"],
         kind="linear",
         bounds_error=False,
-        fill_value=(0.0, curve.table["krw"].max()),
+        fill_value=(0.0, curve.table["KRW"].max()),
     )
 
     # The internal dataframe might contain normalized
@@ -55,11 +55,11 @@ def normalize_nonlinpart_wo(curve):
         return krw_interp(sw_fn(swn))
 
     kro_interp = interp1d(
-        1.0 - curve.table["sw"],
-        curve.table["krow"],
+        1.0 - curve.table["SW"],
+        curve.table["KROW"],
         kind="linear",
         bounds_error=False,
-        fill_value=(0.0, curve.table["krow"].max()),
+        fill_value=(0.0, curve.table["KROW"].max()),
     )
 
     def so_fn(son):
@@ -98,11 +98,11 @@ def normalize_nonlinpart_go(curve):
             evaluate krog on the normalized So interval [0,1].
     """
     krg_interp = interp1d(
-        curve.table["sg"],
-        curve.table["krg"],
+        curve.table["SG"],
+        curve.table["KRG"],
         kind="linear",
         bounds_error=False,
-        fill_value=(0.0, curve.table["krg"].max()),
+        fill_value=(0.0, curve.table["KRG"].max()),
     )
 
     # The internal dataframe might contain normalized
@@ -116,11 +116,11 @@ def normalize_nonlinpart_go(curve):
         return krg_interp(sg_fn(sgn))
 
     kro_interp = interp1d(
-        1.0 - curve.table["sg"],
-        curve.table["krog"],
+        1.0 - curve.table["SG"],
+        curve.table["KROG"],
         kind="linear",
         bounds_error=False,
-        fill_value=(0.0, curve.table["krog"].max()),
+        fill_value=(0.0, curve.table["KROG"].max()),
     )
 
     def so_fn(son):
@@ -150,24 +150,24 @@ def normalize_pc(curve):
         the normalized interval [0,1]
     """
     if isinstance(curve, pyscal.WaterOil):
-        sat_col = "sw"
+        sat_col = "SW"
     elif isinstance(curve, pyscal.GasOil):
-        sat_col = "sg"
+        sat_col = "SG"
     else:
         raise ValueError("Only WaterOil or GasOil allowed as argument")
 
-    if "pc" not in curve.table:
+    if "PC" not in curve.table:
         # Return a dummy zero lambda
         return lambda sxn: 0
 
-    min_pc = curve.table["pc"].min()
-    max_pc = curve.table["pc"].max()
+    min_pc = curve.table["PC"].min()
+    max_pc = curve.table["PC"].max()
     min_sx = curve.table[sat_col].min()
     max_sx = curve.table[sat_col].max()
 
     pc_interp = interp1d(
         curve.table[sat_col],
-        curve.table["pc"],
+        curve.table["PC"],
         kind="linear",
         bounds_error=False,
         fill_value=(max_pc, min_pc),  # This gives constant extrapolation outside [0, 1]
@@ -268,7 +268,7 @@ def interpolate_wo(wo_low, wo_high, parameter, h=0.01, tag=None):
     sorw_new = weighted_value(wo_low.sorw, wo_high.sorw)
 
     # Interpolate kr at saturation endpoints
-    krwmax_new = weighted_value(wo_low.table["krw"].max(), wo_high.table["krw"].max())
+    krwmax_new = weighted_value(wo_low.table["KRW"].max(), wo_high.table["KRW"].max())
     krwend_new = weighted_value(krw1(1), krw2(1))
     kroend_new = weighted_value(kro1(1), kro2(1))
 
@@ -277,11 +277,11 @@ def interpolate_wo(wo_low, wo_high, parameter, h=0.01, tag=None):
     wo_new = pyscal.WaterOil(swl=swl_new, swcr=swcr_new, sorw=sorw_new, h=h, fast=fast)
 
     # Add interpolated relperm data in nonlinear parts:
-    wo_new.table["krw"] = weighted_value(
-        krw1(wo_new.table["swn"]), krw2(wo_new.table["swn"])
+    wo_new.table["KRW"] = weighted_value(
+        krw1(wo_new.table["SWN"]), krw2(wo_new.table["SWN"])
     )
-    wo_new.table["krow"] = weighted_value(
-        kro1(wo_new.table["son"]), kro2(wo_new.table["son"])
+    wo_new.table["KROW"] = weighted_value(
+        kro1(wo_new.table["SON"]), kro2(wo_new.table["SON"])
     )
 
     wo_new.set_endpoints_linearpart_krw(krwend=krwend_new, krwmax=krwmax_new)
@@ -289,10 +289,10 @@ def interpolate_wo(wo_low, wo_high, parameter, h=0.01, tag=None):
 
     # We need a new fit-for-purpose normalized swnpc, that ignores
     # the initial swnpc (swirr-influenced)
-    wo_new.table["swn_pc_intp"] = (wo_new.table["sw"] - wo_new.table["sw"].min()) / (
-        wo_new.table["sw"].max() - wo_new.table["sw"].min()
+    wo_new.table["swn_pc_intp"] = (wo_new.table["SW"] - wo_new.table["SW"].min()) / (
+        wo_new.table["SW"].max() - wo_new.table["SW"].min()
     )
-    wo_new.table["pc"] = weighted_value(
+    wo_new.table["PC"] = weighted_value(
         pc1(wo_new.table["swn_pc_intp"]), pc2(wo_new.table["swn_pc_intp"])
     )
 
@@ -357,7 +357,7 @@ def interpolate_go(go_low, go_high, parameter, h=0.01, tag=None):
     sorg_new = weighted_value(go_low.sorg, go_high.sorg)
 
     # Interpolate kr at saturation endpoints
-    krgmax_new = weighted_value(go_low.table["krg"].max(), go_high.table["krg"].max())
+    krgmax_new = weighted_value(go_low.table["KRG"].max(), go_high.table["KRG"].max())
     krgend_new = weighted_value(krg1(1), krg2(1))
     kroend_new = weighted_value(kro1(1), kro2(1))
 
@@ -366,21 +366,21 @@ def interpolate_go(go_low, go_high, parameter, h=0.01, tag=None):
     go_new = pyscal.GasOil(swl=swl_new, sgcr=sgcr_new, sorg=sorg_new, h=h, fast=fast)
 
     # Add interpolated relperm data in nonlinear parts:
-    go_new.table["krg"] = weighted_value(
-        krg1(go_new.table["sgn"]), krg2(go_new.table["sgn"])
+    go_new.table["KRG"] = weighted_value(
+        krg1(go_new.table["SGN"]), krg2(go_new.table["SGN"])
     )
-    go_new.table["krog"] = weighted_value(
-        kro1(go_new.table["son"]), kro2(go_new.table["son"])
+    go_new.table["KROG"] = weighted_value(
+        kro1(go_new.table["SON"]), kro2(go_new.table["SON"])
     )
-    go_new.table["pc"] = weighted_value(
-        pc1(go_new.table["sgn"]), pc2(go_new.table["sgn"])
+    go_new.table["PC"] = weighted_value(
+        pc1(go_new.table["SGN"]), pc2(go_new.table["SGN"])
     )
 
     # We need a new fit-for-purpose normalized sgnpc
-    go_new.table["sgn_pc_intp"] = (go_new.table["sg"] - go_new.table["sg"].min()) / (
-        go_new.table["sg"].max() - go_new.table["sg"].min()
+    go_new.table["sgn_pc_intp"] = (go_new.table["SG"] - go_new.table["SG"].min()) / (
+        go_new.table["SG"].max() - go_new.table["SG"].min()
     )
-    go_new.table["pc"] = weighted_value(
+    go_new.table["PC"] = weighted_value(
         pc1(go_new.table["sgn_pc_intp"]), pc2(go_new.table["sgn_pc_intp"])
     )
 

--- a/pyscal/utils/testing.py
+++ b/pyscal/utils/testing.py
@@ -98,57 +98,57 @@ def check_table(dframe):
     has the properties that Eclipse enforces"""
     assert not dframe.empty
     assert not dframe.isnull().values.any()
-    if "sw" in dframe and "sg" not in dframe:
+    if "SW" in dframe and "SG" not in dframe:
         # (avoiding GasWater tables, where sw is an auxiliary column)
-        assert len(dframe["sw"].unique()) == len(dframe)
-        assert dframe["sw"].is_monotonic
-        assert (dframe["sw"] >= 0.0).all()
-        assert dframe["swn"].is_monotonic
-        assert dframe["son"].is_monotonic_decreasing
-        assert dframe["swnpc"].is_monotonic
-    if "sg" in dframe:
-        assert len(dframe["sg"].unique()) == len(dframe)
-        assert dframe["sg"].is_monotonic
-        assert (dframe["sg"] >= 0.0).all()
-        assert dframe["sgn"].is_monotonic
-        assert dframe["son"].is_monotonic_decreasing
-    if "krow" in dframe:
-        assert series_decreasing(dframe["krow"])
-        assert (dframe["krow"] >= 0).all()
-        assert (dframe["krow"] <= 1.0).all()
-    if "krw" in dframe:
-        assert series_increasing(dframe["krw"])
-        assert np.isclose(dframe["krw"].iloc[0], 0.0)
-        assert (dframe["krw"] >= 0).all()
-        assert (dframe["krw"] <= 1.0).all()
-    if "pc" in dframe:
-        if "sw" in dframe:
-            assert series_decreasing(dframe["pc"])
-        if "sg" in dframe:
-            assert series_increasing(dframe["pc"])
-    if "krog" in dframe:
-        assert series_decreasing(dframe["krog"])
-        assert (dframe["krog"] >= 0).all()
-        assert (dframe["krog"] <= 1.0).all()
-    if "krg" in dframe:
-        assert series_increasing(dframe["krg"])
-        assert (dframe["krg"] >= 0).all()
-        assert (dframe["krg"] <= 1.0).all()
+        assert len(dframe["SW"].unique()) == len(dframe)
+        assert dframe["SW"].is_monotonic
+        assert (dframe["SW"] >= 0.0).all()
+        assert dframe["SWN"].is_monotonic
+        assert dframe["SON"].is_monotonic_decreasing
+        assert dframe["SWNPC"].is_monotonic
+    if "SG" in dframe:
+        assert len(dframe["SG"].unique()) == len(dframe)
+        assert dframe["SG"].is_monotonic
+        assert (dframe["SG"] >= 0.0).all()
+        assert dframe["SGN"].is_monotonic
+        assert dframe["SON"].is_monotonic_decreasing
+    if "KROW" in dframe:
+        assert series_decreasing(dframe["KROW"])
+        assert (dframe["KROW"] >= 0).all()
+        assert (dframe["KROW"] <= 1.0).all()
+    if "KRW" in dframe:
+        assert series_increasing(dframe["KRW"])
+        assert np.isclose(dframe["KRW"].iloc[0], 0.0)
+        assert (dframe["KRW"] >= 0).all()
+        assert (dframe["KRW"] <= 1.0).all()
+    if "PC" in dframe:
+        if "SW" in dframe:
+            assert series_decreasing(dframe["PC"])
+        if "SG" in dframe:
+            assert series_increasing(dframe["PC"])
+    if "KROG" in dframe:
+        assert series_decreasing(dframe["KROG"])
+        assert (dframe["KROG"] >= 0).all()
+        assert (dframe["KROG"] <= 1.0).all()
+    if "KRG" in dframe:
+        assert series_increasing(dframe["KRG"])
+        assert (dframe["KRG"] >= 0).all()
+        assert (dframe["KRG"] <= 1.0).all()
 
 
 def check_linear_sections(wo_or_go):
     """Check that the linear segments of a WaterOil or a GasOil
     object are linear."""
     if isinstance(wo_or_go, WaterOil):
-        sat_col = "sw"
+        sat_col = "SW"
         right_start = 1 - wo_or_go.sorw
         right_end = 1
-        right_lin_cols = ["krow", "krw"]
-        left_lin_cols = ["krw"]
+        right_lin_cols = ["KROW", "KRW"]
+        left_lin_cols = ["KRW"]
         left_start = wo_or_go.swl
         left_end = wo_or_go.swcr
     if isinstance(wo_or_go, GasOil):
-        sat_col = "sg"
+        sat_col = "SG"
         if wo_or_go.krgendanchor == "sorg":
             right_start = 1 - wo_or_go.sorg - wo_or_go.swl
         else:
@@ -156,8 +156,8 @@ def check_linear_sections(wo_or_go):
             # segment to the right.
             right_start = 1 - wo_or_go.swl
         right_end = 1 - wo_or_go.swl
-        right_lin_cols = ["krog", "krg"]
-        left_lin_cols = ["krg"]
+        right_lin_cols = ["KROG", "KRG"]
+        left_lin_cols = ["KRG"]
         left_start = 0
         left_end = wo_or_go.sgcr
 

--- a/pyscal/wateroilgas.py
+++ b/pyscal/wateroilgas.py
@@ -87,8 +87,8 @@ class WaterOilGas(object):
         if self.wateroil is None:
             logger.error("No WaterOil object in this WaterOilGas object")
             return ""
-        if "krw" not in self.wateroil.table or "krow" not in self.wateroil.table:
-            logger.error("Missing krw/krow curves in WaterOilGas object")
+        if "KRW" not in self.wateroil.table or "KROW" not in self.wateroil.table:
+            logger.error("Missing KRW/KROW curves in WaterOilGas object")
             return ""
         return self.wateroil.SWOF(header, dataincommentrow)
 
@@ -97,8 +97,8 @@ class WaterOilGas(object):
         if self.gasoil is None:
             logger.error("No GasOil object in this WaterOilGas object")
             return ""
-        if "krg" not in self.gasoil.table or "krog" not in self.gasoil.table:
-            logger.error("Missing krg/krog curves in WaterOilGas object")
+        if "KRG" not in self.gasoil.table or "KROG" not in self.gasoil.table:
+            logger.error("Missing KRG/KROG curves in WaterOilGas object")
             return ""
         return self.gasoil.SGOF(header, dataincommentrow)
 
@@ -107,8 +107,8 @@ class WaterOilGas(object):
         if self.gasoil is None:
             logger.error("No GasOil object in this WaterOilGas object")
             return ""
-        if "krg" not in self.gasoil.table or "krog" not in self.gasoil.table:
-            logger.error("Missing krg/krog in WaterOilGas object")
+        if "KRG" not in self.gasoil.table or "KROG" not in self.gasoil.table:
+            logger.error("Missing KRG/KROG in WaterOilGas object")
             return ""
         return self.gasoil.SLGOF(header, dataincommentrow)
 
@@ -117,8 +117,8 @@ class WaterOilGas(object):
         if self.gasoil is None:
             logger.error("No GasOil object in this WaterOilGas object")
             return ""
-        if "krg" not in self.gasoil.table:
-            logger.error("Missing krg in WaterOilGas object")
+        if "KRG" not in self.gasoil.table:
+            logger.error("Missing KRG in WaterOilGas object")
             return ""
         return self.gasoil.SGFN(header, dataincommentrow)
 
@@ -127,8 +127,8 @@ class WaterOilGas(object):
         if self.wateroil is None:
             logger.error("No WaterOil object in this WaterOilGas object")
             return ""
-        if "krw" not in self.wateroil.table:
-            logger.error("Missing krw in WaterOilGas object")
+        if "KRW" not in self.wateroil.table:
+            logger.error("Missing KRW in WaterOilGas object")
             return ""
         return self.wateroil.SWFN(header, dataincommentrow)
 
@@ -139,24 +139,24 @@ class WaterOilGas(object):
         So - the oil saturation ranges from 0 to 1-swl. The saturation points
         from the WaterOil object is used to generate these
         """
-        if "krow" not in self.wateroil.table or "krog" not in self.gasoil.table:
+        if "KROW" not in self.wateroil.table or "KROG" not in self.gasoil.table:
             logger.error("Both WaterOil and GasOil krow/krog is needed for SOF3")
             return ""
         self.threephaseconsistency()
 
         # Copy of the wateroil data:
-        table = pd.DataFrame(self.wateroil.table[["sw", "krow"]])
-        table["so"] = 1 - table["sw"]
+        table = pd.DataFrame(self.wateroil.table[["SW", "KROW"]])
+        table["SO"] = 1 - table["SW"]
 
         # Copy of the gasoil data:
-        gastable = pd.DataFrame(self.gasoil.table[["sg", "krog"]])
-        gastable["so"] = 1 - gastable["sg"] - self.wateroil.swl
+        gastable = pd.DataFrame(self.gasoil.table[["SG", "KROG"]])
+        gastable["SO"] = 1 - gastable["SG"] - self.wateroil.swl
 
         # Merge WaterOil and GasOil on oil saturation, interpolate for
         # missing data (potentially different sg- and sw-grids)
         sof3table = (
             pd.concat([table, gastable], sort=True)
-            .set_index("so")
+            .set_index("SO")
             .sort_index()
             .interpolate(method="slinear")
             .fillna(method="ffill")
@@ -164,14 +164,14 @@ class WaterOilGas(object):
             .reset_index()
         )
         sof3table["soint"] = list(
-            map(int, list(map(round, sof3table["so"] * SWINTEGERS)))
+            map(int, list(map(round, sof3table["SO"] * SWINTEGERS)))
         )
         sof3table.drop_duplicates("soint", inplace=True)
 
         # The 'so' column has been calculated from floating point numbers
         # and the zero value easily becomes a negative zero, circumvent this:
-        zerorow = np.isclose(sof3table["so"], 0.0)
-        sof3table.loc[zerorow, "so"] = abs(sof3table.loc[zerorow, "so"])
+        zerorow = np.isclose(sof3table["SO"], 0.0)
+        sof3table.loc[zerorow, "SO"] = abs(sof3table.loc[zerorow, "SO"])
 
         string = ""
         if header:
@@ -199,7 +199,7 @@ class WaterOilGas(object):
             + "KROG".ljust(width)
             + "\n"
         )
-        string += df2str(sof3table[["so", "krow", "krog"]])
+        string += df2str(sof3table[["SO", "KROW", "KROG"]])
         string += "/\n"
         return string
 
@@ -263,20 +263,20 @@ class WaterOilGas(object):
 
         wog_is_ok = True
         if not np.isclose(
-            self.wateroil.table["krow"].max(), self.gasoil.table["krog"].max()
+            self.wateroil.table["KROW"].max(), self.gasoil.table["KROG"].max()
         ):
             logger.warning(
-                "Eclipse will fail, max(krow)=%g is not equal to max(krog)=%g",
-                self.wateroil.table["krow"].max(),
-                self.gasoil.table["krog"].max(),
+                "Eclipse will fail, max(KROW)=%g is not equal to max(KROG)=%g",
+                self.wateroil.table["KROW"].max(),
+                self.gasoil.table["KROG"].max(),
             )
             wog_is_ok = False
 
         # 2: Inconsistent end points in saturation table 1 the maximum
         # gas saturation (0.91) plus the connate water saturation
         # (0.10) must not exceed 1.0
-        if self.gasoil.table["sg"].max() + self.wateroil.table["sw"].min() > 1.0:
-            logger.warning("Eclipse will fail, max(sg) + Swl > 1.0")
+        if self.gasoil.table["SG"].max() + self.wateroil.table["SW"].min() > 1.0:
+            logger.warning("Eclipse will fail, max(SG) + swl > 1.0")
             wog_is_ok = False
 
         # 3: Warning: Consistency problem for gas phase endpoint (krgr > krg)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -52,9 +52,9 @@ def test_factory_wateroil():
     assert wateroil.swirr == 0.01
     assert wateroil.swl == 0.1
     assert wateroil.tag == "Good sand"
-    assert "krw" in wateroil.table
+    assert "KRW" in wateroil.table
     assert "Corey" in wateroil.krwcomment
-    assert wateroil.table["krw"].max() == 0.2  # Because sorw==0 by default
+    assert wateroil.table["KRW"].max() == 0.2  # Because sorw==0 by default
     check_table(wateroil.table)
     sat_table_str_ok(wateroil.SWOF())
     sat_table_str_ok(wateroil.SWFN())
@@ -63,9 +63,9 @@ def test_factory_wateroil():
         dict(nw=3, now=2, sorw=0.1, krwend=0.2, krwmax=0.5)
     )
     assert isinstance(wateroil, WaterOil)
-    assert "krw" in wateroil.table
+    assert "KRW" in wateroil.table
     assert "Corey" in wateroil.krwcomment
-    assert wateroil.table["krw"].max() == 0.5
+    assert wateroil.table["KRW"].max() == 0.5
     check_table(wateroil.table)
     sat_table_str_ok(wateroil.SWOF())
     sat_table_str_ok(wateroil.SWFN())
@@ -73,7 +73,7 @@ def test_factory_wateroil():
     # Ambiguous works, but we don't guarantee that this results
     # in LET or Corey.
     wateroil = pyscal_factory.create_water_oil(dict(nw=3, Lw=2, Ew=2, Tw=2, now=3))
-    assert "krw" in wateroil.table
+    assert "KRW" in wateroil.table
     assert "Corey" in wateroil.krwcomment or "LET" in wateroil.krwcomment
     check_table(wateroil.table)
     sat_table_str_ok(wateroil.SWOF())
@@ -82,8 +82,8 @@ def test_factory_wateroil():
     # Mixing Corey and LET
     wateroil = pyscal_factory.create_water_oil(dict(Lw=2, Ew=2, Tw=2, krwend=1, now=4))
     assert isinstance(wateroil, WaterOil)
-    assert "krw" in wateroil.table
-    assert wateroil.table["krw"].max() == 1.0
+    assert "KRW" in wateroil.table
+    assert wateroil.table["KRW"].max() == 1.0
     assert "LET" in wateroil.krwcomment
     check_table(wateroil.table)
     sat_table_str_ok(wateroil.SWOF())
@@ -93,10 +93,10 @@ def test_factory_wateroil():
         dict(Lw=2, Ew=2, Tw=2, Low=3, Eow=3, Tow=3, krwend=0.5)
     )
     assert isinstance(wateroil, WaterOil)
-    assert "krw" in wateroil.table
-    assert "krow" in wateroil.table
-    assert wateroil.table["krw"].max() == 0.5
-    assert wateroil.table["krow"].max() == 1
+    assert "KRW" in wateroil.table
+    assert "KROW" in wateroil.table
+    assert wateroil.table["KRW"].max() == 0.5
+    assert wateroil.table["KROW"].max() == 1
     assert "LET" in wateroil.krwcomment
     assert "LET" in wateroil.krowcomment
     check_table(wateroil.table)
@@ -107,8 +107,8 @@ def test_factory_wateroil():
     wateroil = pyscal_factory.create_water_oil(
         dict(swl=0.1, nw=1, now=1, a=2, b=-1, poro_ref=0.2, perm_ref=100, drho=200)
     )
-    assert "pc" in wateroil.table
-    assert wateroil.table["pc"].max() > 0.0
+    assert "PC" in wateroil.table
+    assert wateroil.table["PC"].max() > 0.0
     assert "Simplified J" in wateroil.pccomment
     check_table(wateroil.table)
     sat_table_str_ok(wateroil.SWOF())
@@ -118,8 +118,8 @@ def test_factory_wateroil():
     wateroil = pyscal_factory.create_water_oil(
         dict(swl=0.1, nw=1, now=1, a=2, b=-1, poro_ref=0.2, perm_ref=100, drho=200, g=0)
     )
-    assert "pc" in wateroil.table
-    assert wateroil.table["pc"].max() == 0.0
+    assert "PC" in wateroil.table
+    assert wateroil.table["PC"].max() == 0.0
     check_table(wateroil.table)
     sat_table_str_ok(wateroil.SWOF())
     sat_table_str_ok(wateroil.SWFN())
@@ -137,8 +137,8 @@ def test_factory_wateroil():
             drho=200,
         )
     )
-    assert "pc" in wateroil.table
-    assert wateroil.table["pc"].max() > 0.0
+    assert "PC" in wateroil.table
+    assert wateroil.table["PC"].max() > 0.0
     assert "etrophysic" in wateroil.pccomment
     check_table(wateroil.table)
     sat_table_str_ok(wateroil.SWOF())
@@ -148,7 +148,7 @@ def test_factory_wateroil():
     wateroil = pyscal_factory.create_water_oil(
         dict(swl=0.1, nw=1, now=1, a=2, b=-1, perm_ref=100, drho=200, g=0)
     )
-    assert "pc" not in wateroil.table
+    assert "PC" not in wateroil.table
 
 
 def test_fast_mode():
@@ -375,7 +375,7 @@ def test_ambiguity():
     )
     # Corey is picked here.
     assert "Corey" in wateroil.krwcomment
-    assert "krw" in wateroil.table
+    assert "KRW" in wateroil.table
 
 
 def test_factory_gasoil():
@@ -560,7 +560,7 @@ def test_factory_wateroilgas_wo():
     )
     swof = wog.SWOF()
     assert "Corey krw" in swof
-    assert "krw" in wog.wateroil.table
+    assert "KRW" in wog.wateroil.table
     sat_table_str_ok(swof)
     check_table(wog.wateroil.table)
     assert wog.gasoil is None
@@ -853,12 +853,12 @@ def test_check_deprecated_krowgend(caplog):
     wateroil = PyscalFactory.create_water_oil(dict(swl=0.1, nw=2, now=2, krowend=0.4))
     assert "krowend" in caplog.text
     assert "deprecated" in caplog.text
-    assert wateroil.table["krow"].max() == 0.4
+    assert wateroil.table["KROW"].max() == 0.4
 
     gasoil = PyscalFactory.create_gas_oil(dict(swl=0.1, ng=2, nog=2, krogend=0.4))
     assert "krogend" in caplog.text
     assert "deprecated" in caplog.text
-    assert gasoil.table["krog"].max() == 0.4
+    assert gasoil.table["KROG"].max() == 0.4
 
 
 def test_check_deprecated_kromax(caplog):

--- a/tests/test_fromtable.py
+++ b/tests/test_fromtable.py
@@ -21,25 +21,16 @@ def test_wo_fromtable_simple():
     wateroil = WaterOil(h=0.1)
     # With wrong names:
     with pytest.raises(ValueError):
-        wateroil.add_fromtable(df1)
+        wateroil.add_fromtable(df1, swcolname="sw")
 
     # Set names:
-    wateroil.add_fromtable(df1, swcolname="SW")
-    # This didn't do anything, because we did not provide any relperm names
-    assert "krw" not in wateroil.table.columns
-    assert "krow" not in wateroil.table.columns
-    assert "pc" not in wateroil.table.columns
-
-    # Try again:
-    wateroil.add_fromtable(
-        df1, swcolname="SW", krwcolname="KRW", krowcolname="KROW", pccolname="PC"
-    )
-    assert "krw" in wateroil.table.columns
-    assert "krow" in wateroil.table.columns
-    assert "pc" in wateroil.table.columns
-    assert sum(wateroil.table["krw"]) > 0
-    assert sum(wateroil.table["krow"]) > 0
-    assert np.isclose(sum(wateroil.table["pc"]), 11)  # Linearly increasing PC
+    wateroil.add_fromtable(df1, swcolname="SW", pccolname="PC")
+    assert "KRW" in wateroil.table.columns
+    assert "KROW" in wateroil.table.columns
+    assert "PC" in wateroil.table.columns
+    assert sum(wateroil.table["KRW"]) > 0
+    assert sum(wateroil.table["KROW"]) > 0
+    assert np.isclose(sum(wateroil.table["PC"]), 11)  # Linearly increasing PC
     check_table(wateroil.table)
 
 
@@ -52,9 +43,9 @@ def test_go_fromtable_simple():
     gasoil.add_fromtable(
         df1, sgcolname="SG", krgcolname="KRG", krogcolname="KROG", pccolname="PC"
     )
-    assert sum(gasoil.table["krg"]) > 0
-    assert sum(gasoil.table["krog"]) > 0
-    assert np.isclose(sum(gasoil.table["pc"]), 11)  # Linearly increasing PCOG
+    assert sum(gasoil.table["KRG"]) > 0
+    assert sum(gasoil.table["KROG"]) > 0
+    assert np.isclose(sum(gasoil.table["PC"]), 11)  # Linearly increasing PCOG
     check_table(gasoil.table)
 
 
@@ -78,16 +69,16 @@ def test_wo_fromtable_multiindex():
     wateroil.add_fromtable(
         df1, swcolname="SW", krwcolname="KRW", krowcolname="KROW", pccolname="PC"
     )
-    assert "krw" in wateroil.table.columns
-    assert "krow" in wateroil.table.columns
-    assert "pc" in wateroil.table.columns
+    assert "KRW" in wateroil.table.columns
+    assert "KROW" in wateroil.table.columns
+    assert "PC" in wateroil.table.columns
     check_table(wateroil.table)
 
 
 def test_go_fromtable_problems():
     """Test loading from a table where there should be problems"""
     df1 = pd.DataFrame(
-        columns=["Sg", "KRG", "KROG", "PCOG"], data=[[0.1, 0, 1, 0], [0.9, 1, 0, 2]]
+        columns=["SG", "KRG", "KROG", "PCOG"], data=[[0.1, 0, 1, 0], [0.9, 1, 0, 2]]
     )
     # Now sgcr and swl is wrong:
     gasoil = GasOil(h=0.1)
@@ -95,7 +86,7 @@ def test_go_fromtable_problems():
         # Should say sg must start at zero.
         gasoil.add_fromtable(df1, pccolname="PCOG")
     df2 = pd.DataFrame(
-        columns=["Sg", "KRG", "KROG", "PCOG"], data=[[0.0, 0, 1, 0], [0.9, 0.8, 0, 2]]
+        columns=["SG", "KRG", "KROG", "PCOG"], data=[[0.0, 0, 1, 0], [0.9, 0.8, 0, 2]]
     )
     with pytest.raises(ValueError):
         # should say too large swl for pcog interpolation
@@ -103,24 +94,24 @@ def test_go_fromtable_problems():
         gasoil.add_fromtable(df2, pccolname="PCOG")
     gasoil = GasOil(h=0.1, swl=0.1)
     gasoil.add_fromtable(df2, pccolname="PCOG")
-    assert np.isclose(gasoil.table["pc"].max(), 2.0)
-    assert np.isclose(gasoil.table["pc"].min(), 0.0)
-    assert np.isclose(gasoil.table["sg"].max(), 0.9)
+    assert np.isclose(gasoil.table["PC"].max(), 2.0)
+    assert np.isclose(gasoil.table["PC"].min(), 0.0)
+    assert np.isclose(gasoil.table["SG"].max(), 0.9)
 
     gasoil = GasOil(h=0.1)
     with pytest.raises(ValueError):
         # sg must start at zero
         gasoil.add_fromtable(df1, krgcolname="KRG", krogcolname="KROG")
     # This works fine, but we get warnings on swl not seemingly correct
-    gasoil.add_fromtable(df2, krgcolname="KRG", krogcolname="KROG")
+    gasoil.add_fromtable(df2, krgcolname="KRG", krogcolname="KROG", pccolname=None)
     # krg will be extrapolated to sg=1
-    float_df_checker(gasoil.table, "sg", 1.0, "krg", 0.8)
-    float_df_checker(gasoil.table, "sg", 1.0, "krog", 0.0)
+    float_df_checker(gasoil.table, "SG", 1.0, "KRG", 0.8)
+    float_df_checker(gasoil.table, "SG", 1.0, "KROG", 0.0)
     gasoil = GasOil(h=0.1, swl=0.1)
     gasoil.add_fromtable(df2, krgcolname="KRG", krogcolname="KROG")
 
     df3 = pd.DataFrame(
-        columns=["Sg", "KRG", "KROG", "PCOG"], data=[[0, -0.01, 1, 0], [1, 1, 0, 0]]
+        columns=["SG", "KRG", "KROG", "PCOG"], data=[[0, -0.01, 1, 0], [1, 1, 0, 0]]
     )
     gasoil = GasOil(h=0.1)
     with pytest.raises(ValueError):
@@ -128,7 +119,7 @@ def test_go_fromtable_problems():
         gasoil.add_fromtable(df3, krgcolname="KRG")
 
     df4 = pd.DataFrame(
-        columns=["Sg", "KRG", "KROG", "PCOG"],
+        columns=["SG", "KRG", "KROG", "PCOG"],
         data=[[0, 0, 1, 0], [1, 1.0000000001, 0, 0]],
     )
     gasoil = GasOil(h=0.1)
@@ -140,45 +131,45 @@ def test_go_fromtable_problems():
 
 def test_wo_singlecolumns():
     """Test that we can load single columns from individual dataframes"""
-    krw = pd.DataFrame(columns=["Sw", "krw"], data=[[0.15, 0], [0.89, 1], [1, 1]])
-    krow = pd.DataFrame(columns=["Sw", "krow"], data=[[0.15, 1], [0.89, 0], [1, 0]])
-    pc1 = pd.DataFrame(columns=["Sw", "pcow"], data=[[0.15, 3], [0.89, 0.1], [1, 0]])
+    krw = pd.DataFrame(columns=["SW", "KRW"], data=[[0.15, 0], [0.89, 1], [1, 1]])
+    krow = pd.DataFrame(columns=["SW", "KROW"], data=[[0.15, 1], [0.89, 0], [1, 0]])
+    pc1 = pd.DataFrame(columns=["SW", "PCOW"], data=[[0.15, 3], [0.89, 0.1], [1, 0]])
     wateroil = WaterOil(h=0.1, swl=0.15, sorw=1 - 0.89)
     wateroil.add_fromtable(krw)
-    assert "krw" in wateroil.table
-    assert "krow" not in wateroil.table
+    assert "KRW" in wateroil.table
+    assert "KROW" not in wateroil.table
     wateroil.add_fromtable(krow)
-    assert "krow" in wateroil.table
+    assert "KROW" in wateroil.table
     wateroil.add_fromtable(pc1)
-    assert "pc" in wateroil.table
+    assert "PC" in wateroil.table
 
     # We want to allow a pc dataframe where sw starts from zero:
     # then should not preserve pc(sw=0)
-    pc2 = pd.DataFrame(columns=["Sw", "pcow"], data=[[0, 3], [0.5, 0.1], [1, 0]])
+    pc2 = pd.DataFrame(columns=["SW", "PCOW"], data=[[0, 3], [0.5, 0.1], [1, 0]])
     wateroil.add_fromtable(pc2)
-    assert "pc" in wateroil.table
-    assert wateroil.table["sw"].min() == 0.15
-    assert wateroil.table["pc"].max() < 3
+    assert "PC" in wateroil.table
+    assert wateroil.table["SW"].min() == 0.15
+    assert wateroil.table["PC"].max() < 3
 
     # But we should refuse a pc dataframe not covering our sw range:
     wateroil = WaterOil(h=0.1, swl=0)
     with pytest.raises(ValueError):
-        pc3 = pd.DataFrame(columns=["Sw", "pcow"], data=[[0.1, 3], [0.5, 0.1], [1, 0]])
+        pc3 = pd.DataFrame(columns=["SW", "PCOW"], data=[[0.1, 3], [0.5, 0.1], [1, 0]])
         wateroil.add_fromtable(pc3)
     with pytest.raises(ValueError):
-        pc3 = pd.DataFrame(columns=["Sw", "pcow"], data=[[0, 3], [0.5, 0.1]])
+        pc3 = pd.DataFrame(columns=["SW", "PCOW"], data=[[0, 3], [0.5, 0.1]])
         wateroil.add_fromtable(pc3)
 
     # Disallow non-monotonous capillary pressure:
-    pc4 = pd.DataFrame(columns=["Sw", "pcow"], data=[[0.15, 3], [0.89, 0.1], [1, 0.1]])
+    pc4 = pd.DataFrame(columns=["SW", "PCOW"], data=[[0.15, 3], [0.89, 0.1], [1, 0.1]])
     with pytest.raises(ValueError):
         wateroil.add_fromtable(pc4)
 
     # But if capillary pressure is all zero, accept it:
-    pc5 = pd.DataFrame(columns=["Sw", "pcow"], data=[[0, 0], [1, 0]])
+    pc5 = pd.DataFrame(columns=["SW", "PCOW"], data=[[0, 0], [1, 0]])
     wateroil = WaterOil(h=0.1)
     wateroil.add_fromtable(pc5)
-    assert wateroil.table["pc"].sum() == 0
+    assert wateroil.table["PC"].sum() == 0
 
 
 def test_ieee_754():
@@ -191,119 +182,125 @@ def test_ieee_754():
 
     # Can we then interpolate from a table that goes up to 0.82?
     sgof = pd.DataFrame(
-        columns=["Sg", "krg", "krog", "pcog"], data=[[0, 0, 1, 0], [0.82, 1, 0, 0]]
+        columns=["SG", "KRG", "KROG", "PCOG"], data=[[0, 0, 1, 0], [0.82, 1, 0, 0]]
     )
     # Note, replacing 0.82 in the table above with 1-0.18 *is not the same*
     wateroilgas.gasoil.add_fromtable(sgof)
-    assert wateroilgas.gasoil.table["krg"].max() == 1.0
-    assert wateroilgas.gasoil.table["krog"].min() == 0.0
-    assert wateroilgas.gasoil.table["pc"].min() == 0.0
-    assert wateroilgas.gasoil.table["pc"].max() == 0.0
+    assert wateroilgas.gasoil.table["KRG"].max() == 1.0
+    assert wateroilgas.gasoil.table["KROG"].min() == 0.0
+    assert wateroilgas.gasoil.table["PC"].min() == 0.0
+    assert wateroilgas.gasoil.table["PC"].max() == 0.0
 
 
 def test_wo_invalidcurves():
     """Test what happens when we give in invalid data"""
     # Sw data not ordered:
-    krw1 = pd.DataFrame(columns=["Sw", "krw"], data=[[0.15, 0], [0.1, 1], [1, 1]])
-    wateroil = WaterOil(swl=krw1["Sw"].min(), h=0.1)
+    krw1 = pd.DataFrame(columns=["SW", "KRW"], data=[[0.15, 0], [0.1, 1], [1, 1]])
+    wateroil = WaterOil(swl=krw1["SW"].min(), h=0.1)
     with pytest.raises(ValueError):
         # pchip-interpolator raises this error;
         # x coordinates are not in increasing order
-        wateroil.add_fromtable(krw1, krwcolname="krw")
+        wateroil.add_fromtable(krw1, krwcolname="KRW")
 
     krw2 = pd.DataFrame(
-        columns=["Sw", "krw"], data=[[0.15, 0], [0.4, 0.6], [0.6, 0.4], [1, 1]]
+        columns=["SW", "KRW"], data=[[0.15, 0], [0.4, 0.6], [0.6, 0.4], [1, 1]]
     )
-    wateroil = WaterOil(swl=krw2["Sw"].min(), h=0.1)
+    wateroil = WaterOil(swl=krw2["SW"].min(), h=0.1)
     with pytest.raises(ValueError):
         # Should get notified that krw is not monotonous
-        wateroil.add_fromtable(krw2, krwcolname="krw")
+        wateroil.add_fromtable(krw2, krwcolname="KRW")
     krow2 = pd.DataFrame(
-        columns=["Sw", "krow"], data=[[0.15, 1], [0.4, 0.4], [0.6, 0.6], [1, 0]]
+        columns=["SW", "KROW"], data=[[0.15, 1], [0.4, 0.4], [0.6, 0.6], [1, 0]]
     )
-    wateroil = WaterOil(swl=krow2["Sw"].min(), h=0.1)
+    wateroil = WaterOil(swl=krow2["SW"].min(), h=0.1)
     with pytest.raises(ValueError):
         # Should get notified that krow is not monotonous
-        wateroil.add_fromtable(krow2, krowcolname="krow")
+        wateroil.add_fromtable(krow2, krowcolname="KROW")
     pc2 = pd.DataFrame(
-        columns=["Sw", "pc"], data=[[0.15, 1], [0.4, 0.4], [0.6, 0.6], [1, 0]]
+        columns=["SW", "PC"], data=[[0.15, 1], [0.4, 0.4], [0.6, 0.6], [1, 0]]
     )
-    wateroil = WaterOil(swl=pc2["Sw"].min(), h=0.1)
+    wateroil = WaterOil(swl=pc2["SW"].min(), h=0.1)
     with pytest.raises(ValueError):
         # Should get notified that pc is not monotonous
-        wateroil.add_fromtable(pc2, pccolname="pc")
+        wateroil.add_fromtable(pc2, pccolname="PC")
 
     pc3 = pd.DataFrame(
-        columns=["Sw", "pc"],
+        columns=["SW", "PC"],
         data=[[0, np.inf], [0.1, 1], [0.4, 0.4], [0.6, 0.2], [1, 0]],
     )
-    wateroil = WaterOil(swl=pc3["Sw"].min(), h=0.1)
+    wateroil = WaterOil(swl=pc3["SW"].min(), h=0.1)
     # Will get warning that infinite numbers are ignored.
     # In this case the extrapolation is quite bad.
-    wateroil.add_fromtable(pc3, pccolname="pc")
+    wateroil.add_fromtable(pc3, pccolname="PC")
 
     # But when we later set swl larger, then we should
     # not bother about the infinity:
     wateroil = WaterOil(swl=0.1, h=0.1)
-    wateroil.add_fromtable(pc3, pccolname="pc")
-    assert np.isclose(wateroil.table["pc"].max(), pc3.iloc[1:]["pc"].max())
+    wateroil.add_fromtable(pc3, pccolname="PC")
+    assert np.isclose(wateroil.table["PC"].max(), pc3.iloc[1:]["PC"].max())
 
     # Choosing endpoint slightly to the left of 0.1 incurs
     # extrapolation. A warning will be given
     wateroil = WaterOil(swl=0.05, h=0.1)
-    wateroil.add_fromtable(pc3, pccolname="pc")
+    wateroil.add_fromtable(pc3, pccolname="PC")
     # Inequality due to extrapolation:
-    assert wateroil.table["pc"].max() > pc3.iloc[1:]["pc"].max()
+    assert wateroil.table["PC"].max() > pc3.iloc[1:]["PC"].max()
 
 
 def test_go_invalidcurves():
     """Test  fromtable on invalid gasoil data"""
     # Sw data not ordered:
-    krg1 = pd.DataFrame(columns=["Sg", "krg"], data=[[0.15, 0], [0.1, 1], [1, 1]])
+    krg1 = pd.DataFrame(columns=["SG", "KRG"], data=[[0.15, 0], [0.1, 1], [1, 1]])
     gasoil = GasOil(h=0.1)
     with pytest.raises(ValueError):
         # pchip-interpolator raises this error;
         # x coordinates are not in increasing order
-        gasoil.add_fromtable(krg1, krgcolname="krg")
+        gasoil.add_fromtable(krg1, krgcolname="KRG")
 
     krg2 = pd.DataFrame(
-        columns=["Sg", "krg"], data=[[0.15, 0], [0.4, 0.6], [0.6, 0.4], [1, 1]]
+        columns=["SG", "KRG"], data=[[0.15, 0], [0.4, 0.6], [0.6, 0.4], [1, 1]]
     )
     gasoil = GasOil(h=0.1)
     with pytest.raises(ValueError):
         # Should get notified that krg is not monotonous
-        gasoil.add_fromtable(krg2, krgcolname="krg")
+        gasoil.add_fromtable(krg2, krgcolname="KRG")
     krog2 = pd.DataFrame(
-        columns=["Sg", "krog"], data=[[0.15, 1], [0.4, 0.4], [0.6, 0.6], [1, 0]]
+        columns=["SG", "KROG"], data=[[0.15, 1], [0.4, 0.4], [0.6, 0.6], [1, 0]]
     )
     gasoil = GasOil(h=0.1)
     with pytest.raises(ValueError):
         # Should get notified that krog is not monotonous
-        gasoil.add_fromtable(krog2, krogcolname="krog")
+        gasoil.add_fromtable(krog2, krogcolname="KROG")
     pc2 = pd.DataFrame(
-        columns=["Sg", "pc"], data=[[0.15, 1], [0.4, 0.4], [0.6, 0.6], [1, 0]]
+        columns=["SG", "PC"], data=[[0.15, 1], [0.4, 0.4], [0.6, 0.6], [1, 0]]
     )
     gasoil = GasOil(h=0.1)
     with pytest.raises(ValueError):
         # Should get notified that pc is not monotonous
-        gasoil.add_fromtable(pc2, pccolname="pc")
+        gasoil.add_fromtable(pc2, pccolname="PC")
 
 
 def test_wo_fromtable_problems():
     """Test wateroil from tables with problematic data"""
     # With default object:
     df1 = pd.DataFrame(
-        columns=["Sw", "krw", "krow", "pcow"],
+        columns=["SW", "KRW", "KROW", "PCOW"],
         data=[[0.15, 0, 1, 3], [0.89, 1, 0, 0.1], [1, 1, 0, 0]],
     )
-    wateroil = WaterOil(h=0.1, swl=df1["Sw"].min())
+    # With default object:
+    wateroil = WaterOil(h=0.1)
+    with pytest.raises(ValueError):
+        wateroil.add_fromtable(df1)
+        # This results in krw and krow overshooting 0 and 1
+    # Fix left endpoint:
+    wateroil = WaterOil(h=0.1, swl=df1["SW"].min())
     wateroil.add_fromtable(df1)
     # The table is now valid, but we did not preserve the 0.89 point
     check_table(wateroil.table)
 
     # If we also tell the WaterOil object about sorw, we are guaranteed
     # to have it expclitly included:
-    wateroil = WaterOil(h=0.1, swl=df1["Sw"].min(), sorw=1 - 0.89)
+    wateroil = WaterOil(h=0.1, swl=df1["SW"].min(), sorw=1 - 0.89)
     wateroil.add_fromtable(df1)
     check_table(wateroil.table)
     # For low enough h, this will however NOT matter.
@@ -314,61 +311,61 @@ def test_wo_fromtable_problems():
     [
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, "fooo", 1, 3], [0.89, 1, 0, 0.1], [1, 1, 0, 0]],
             ),
             0.15,
             ValueError,
-            "Failed to parse column krw",
+            "Failed to parse column KRW",
         ),
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, 1.1, 1, 3], [0.89, 1, 0, 0.1], [1, 1, 0, 0]],
             ),
             0.15,
             ValueError,
-            "krw is above 1",
+            "KRW is above 1",
         ),
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, -0.1, 1, 3], [0.89, 1, 0, 0.1], [1, 1, 0, 0]],
             ),
             0.15,
             ValueError,
-            "krw is below 0",
+            "KRW is below 0",
         ),
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, 0.1, "foo", 3], [0.89, 1, 0, 0.1], [1, 1, 0, 0]],
             ),
             0.15,
             ValueError,
-            "Failed to parse column krow",
+            "Failed to parse column KROW",
         ),
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, 0.1, 1.1, 3], [0.89, 1, 0, 0.1], [1, 1, 0, 0]],
             ),
             0.15,
             ValueError,
-            "krow is above 1",
+            "KROW is above 1",
         ),
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, 0.1, 1, 3], [0.89, 1, 0, 0.1], [1, 1, -0.001, 0]],
             ),
             0.15,
             ValueError,
-            "krow is below 0",
+            "KROW is below 0",
         ),
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, 0.1, 1, 3], [0.89, 1, 0, 0.1], [1, 1, -0.001, 0]],
             ),
             0.10,
@@ -377,7 +374,7 @@ def test_wo_fromtable_problems():
         ),
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, 0.1, 1, 3], [0.89, 1, 0, 0.1], [1, 1, -0.001, 0]],
             ),
             0,
@@ -386,7 +383,7 @@ def test_wo_fromtable_problems():
         ),
         (
             pd.DataFrame(
-                columns=["Sw", "krw", "krow", "pcow"],
+                columns=["SW", "KRW", "KROW", "PCOW"],
                 data=[[0.15, 0.1, 1, 3], [0.89, 1, 0, 0.1], [1, 1, -0.001, 0]],
             ),
             0.16,
@@ -415,18 +412,18 @@ def test_fromtable_types():
     wateroil.add_fromtable(
         df1, swcolname="SW", krwcolname="KRW", krowcolname="KROW", pccolname="PC"
     )
-    assert "krw" in wateroil.table.columns
-    assert "krow" in wateroil.table.columns
-    assert "pc" in wateroil.table.columns
+    assert "KRW" in wateroil.table.columns
+    assert "KROW" in wateroil.table.columns
+    assert "PC" in wateroil.table.columns
     check_table(wateroil.table)
 
     gasoil = GasOil(h=0.1)
     gasoil.add_fromtable(
         df1, sgcolname="SW", krgcolname="KRW", krogcolname="KROW", pccolname="PC"
     )
-    assert "krg" in gasoil.table.columns
-    assert "krog" in gasoil.table.columns
-    assert "pc" in gasoil.table.columns
+    assert "KRG" in gasoil.table.columns
+    assert "KROG" in gasoil.table.columns
+    assert "PC" in gasoil.table.columns
     check_table(gasoil.table)
 
     # But this should not make sense.
@@ -451,7 +448,7 @@ def test_fromtable_types():
 def test_wo_fromtable_h(h):
     """Test making curves from tabular data with random stepsize h"""
     df1 = pd.DataFrame(
-        columns=["Sw", "krw", "krow", "pcow"],
+        columns=["SW", "KRW", "KROW", "PCOW"],
         data=[[0.15, 0, 1, 3], [0.89, 1, 0, 0.1], [1, 1, 0, 0]],
     )
     wateroil = WaterOil(h=h, swl=0.15, sorw=1 - 0.89)

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -61,8 +61,8 @@ def test_gasoil_init():
     gasoil.add_corey_oil()
     assert len(gasoil.table) == 2
     assert np.isclose(gasoil.crosspoint(), 0.45)
-    assert np.isclose(gasoil.table["sg"].min(), 0)
-    assert np.isclose(gasoil.table["sg"].max(), 0.9)
+    assert np.isclose(gasoil.table["SG"].min(), 0)
+    assert np.isclose(gasoil.table["SG"].max(), 0.9)
 
     # Test too small h:
     gasoil = GasOil(swl=0.1, h=0.00000000000000000001)
@@ -115,23 +115,23 @@ def test_gasoil_normalization(swl, sgcr, sorg, h, tag):
     assert not gasoil.table.isnull().values.any()
 
     # Check that son is 1 at sg=0
-    assert float_df_checker(gasoil.table, "sg", 0, "son", 1)
+    assert float_df_checker(gasoil.table, "SG", 0, "SON", 1)
 
     # Check that son is 0 at sorg with this krgendanchor
-    assert float_df_checker(gasoil.table, "sg", 1 - gasoil.sorg - gasoil.swl, "son", 0)
+    assert float_df_checker(gasoil.table, "SG", 1 - gasoil.sorg - gasoil.swl, "SON", 0)
 
     # Check that sgn is 0 at sgcr
-    assert float_df_checker(gasoil.table, "sg", gasoil.sgcr, "sgn", 0)
+    assert float_df_checker(gasoil.table, "SG", gasoil.sgcr, "SGN", 0)
 
     # Check that sgn is 1 at sorg
-    assert float_df_checker(gasoil.table, "sg", 1 - gasoil.sorg - gasoil.swl, "sgn", 1)
+    assert float_df_checker(gasoil.table, "SG", 1 - gasoil.sorg - gasoil.swl, "SGN", 1)
 
     # Redo with different krgendanchor
     gasoil = GasOil(
         swirr=0.0, swl=swl, sgcr=sgcr, sorg=sorg, h=h, krgendanchor="", tag=tag
     )
-    assert float_df_checker(gasoil.table, "sg", 1 - gasoil.swl, "sgn", 1)
-    assert float_df_checker(gasoil.table, "sg", gasoil.sgcr, "sgn", 0)
+    assert float_df_checker(gasoil.table, "SG", 1 - gasoil.swl, "SGN", 1)
+    assert float_df_checker(gasoil.table, "SG", gasoil.sgcr, "SGN", 0)
 
 
 @settings(deadline=1000)
@@ -192,21 +192,21 @@ def check_endpoints(gasoil, krgend, krgmax, kroend):
     # Check endpoints for oil curve:
     # krog at sgcr should be kroend
     if gasoil.sgcr > swtol:
-        assert float_df_checker(gasoil.table, "son", 1.0, "krog", kroend)
+        assert float_df_checker(gasoil.table, "SON", 1.0, "KROG", kroend)
     # krog at son=0 (1-sorg-swl or 1 - swl) should be zero:
-    assert float_df_checker(gasoil.table, "son", 0.0, "krog", 0)
+    assert float_df_checker(gasoil.table, "SON", 0.0, "KROG", 0)
 
-    assert float_df_checker(gasoil.table, "sg", 0, "krog", kroend)
+    assert float_df_checker(gasoil.table, "SG", 0, "KROG", kroend)
 
-    assert float_df_checker(gasoil.table, "sgn", 0.0, "krg", 0)
-    assert float_df_checker(gasoil.table, "sg", gasoil.sgcr, "krg", 0)
+    assert float_df_checker(gasoil.table, "SGN", 0.0, "KRG", 0)
+    assert float_df_checker(gasoil.table, "SG", gasoil.sgcr, "KRG", 0)
 
     # If krgendanchor == "sorg" then krgmax is irrelevant.
     if gasoil.sorg > swtol and gasoil.sorg > gasoil.h and gasoil.krgendanchor == "sorg":
-        assert float_df_checker(gasoil.table, "sgn", 1.0, "krg", krgend)
-        assert np.isclose(gasoil.table["krg"].max(), krgmax)
+        assert float_df_checker(gasoil.table, "SGN", 1.0, "KRG", krgend)
+        assert np.isclose(gasoil.table["KRG"].max(), krgmax)
     if gasoil.krgendanchor != "sorg":
-        assert np.isclose(gasoil.table["krg"].max(), krgend)
+        assert np.isclose(gasoil.table["KRG"].max(), krgend)
 
 
 def test_gasoil_krgendanchor():
@@ -218,10 +218,10 @@ def test_gasoil_krgendanchor():
 
     # kg should be 1.0 at 1 - sorg due to krgendanchor == "sorg":
     assert (
-        gasoil.table[np.isclose(gasoil.table["sg"], 1 - gasoil.sorg)]["krg"].values[0]
+        gasoil.table[np.isclose(gasoil.table["SG"], 1 - gasoil.sorg)]["KRG"].values[0]
         == 1.0
     )
-    assert gasoil.table[np.isclose(gasoil.table["sg"], 1.0)]["krg"].values[0] == 1.0
+    assert gasoil.table[np.isclose(gasoil.table["SG"], 1.0)]["KRG"].values[0] == 1.0
 
     gasoil = GasOil(krgendanchor="", sorg=0.2, h=0.1)
     assert gasoil.sorg
@@ -230,10 +230,10 @@ def test_gasoil_krgendanchor():
 
     # kg should be < 1 at 1 - sorg due to krgendanchor being ""
     assert (
-        gasoil.table[np.isclose(gasoil.table["sg"], 1 - gasoil.sorg)]["krg"].values[0]
+        gasoil.table[np.isclose(gasoil.table["SG"], 1 - gasoil.sorg)]["KRG"].values[0]
         < 1.0
     )
-    assert gasoil.table[np.isclose(gasoil.table["sg"], 1.0)]["krg"].values[0] == 1.0
+    assert gasoil.table[np.isclose(gasoil.table["SG"], 1.0)]["KRG"].values[0] == 1.0
     assert gasoil.selfcheck()
     assert gasoil.crosspoint() > 0
 
@@ -247,10 +247,10 @@ def test_gasoil_krgendanchor():
 
     # kg should be 1.0 at 1 - sorg due to krgendanchor == "sorg":
     assert (
-        gasoil.table[np.isclose(gasoil.table["sg"], 1 - gasoil.sorg)]["krg"].values[0]
+        gasoil.table[np.isclose(gasoil.table["SG"], 1 - gasoil.sorg)]["KRG"].values[0]
         == 1.0
     )
-    assert gasoil.table[np.isclose(gasoil.table["sg"], 1.0)]["krg"].values[0] == 1.0
+    assert gasoil.table[np.isclose(gasoil.table["SG"], 1.0)]["KRG"].values[0] == 1.0
 
     gasoil = GasOil(krgendanchor="", sorg=0.2, h=0.1)
     assert gasoil.sorg
@@ -261,10 +261,10 @@ def test_gasoil_krgendanchor():
 
     # kg should be < 1 at 1 - sorg due to krgendanchor being ""
     assert (
-        gasoil.table[np.isclose(gasoil.table["sg"], 1 - gasoil.sorg)]["krg"].values[0]
+        gasoil.table[np.isclose(gasoil.table["SG"], 1 - gasoil.sorg)]["KRG"].values[0]
         < 1.0
     )
-    assert gasoil.table[np.isclose(gasoil.table["sg"], 1.0)]["krg"].values[0] == 1.0
+    assert gasoil.table[np.isclose(gasoil.table["SG"], 1.0)]["KRG"].values[0] == 1.0
 
 
 def test_nexus():
@@ -303,17 +303,17 @@ def test_kroend():
     gasoil = GasOil(swirr=0.01, sgcr=0.01, h=0.01, swl=0.1, sorg=0.05)
     gasoil.add_LET_gas()
     gasoil.add_LET_oil(2, 2, 2.1)
-    assert gasoil.table["krog"].max() == 1
+    assert gasoil.table["KROG"].max() == 1
     gasoil.add_LET_oil(2, 2, 2.1, kroend=0.5)
     check_linear_sections(gasoil)
-    assert gasoil.table["krog"].max() == 0.5
+    assert gasoil.table["KROG"].max() == 0.5
 
     assert 0 < gasoil.crosspoint() < 1
 
     gasoil.add_corey_oil(2)
-    assert gasoil.table["krog"].max() == 1
+    assert gasoil.table["KROG"].max() == 1
     gasoil.add_corey_oil(nog=2, kroend=0.5)
-    assert gasoil.table["krog"].max() == 0.5
+    assert gasoil.table["KROG"].max() == 0.5
 
 
 @settings(deadline=1500)
@@ -328,8 +328,8 @@ def test_gasoil_corey1(ng, nog):
         # This happens for "invalid" input
         return
 
-    assert "krog" in gasoil.table
-    assert "krg" in gasoil.table
+    assert "KROG" in gasoil.table
+    assert "KRG" in gasoil.table
     assert isinstance(gasoil.krgcomment, str)
     check_table(gasoil.table)
     sgofstr = gasoil.SGOF()
@@ -395,8 +395,8 @@ def test_gasoil_let1(l, e, t, krgend, krgmax):
     except AssertionError:
         # This happens for negative values f.ex.
         return
-    assert "krog" in gasoil.table
-    assert "krg" in gasoil.table
+    assert "KROG" in gasoil.table
+    assert "KRG" in gasoil.table
     assert isinstance(gasoil.krgcomment, str)
     check_table(gasoil.table)
     check_linear_sections(gasoil)
@@ -424,7 +424,7 @@ def test_fast():
     assert "-- krg = krog @ sg=0.5" in gasoil.SGOF()
 
     # Provoke non-strict-monotone krow:
-    gasoil.table.loc[0:2, "krog"] = [1.00, 0.81, 0.81]
+    gasoil.table.loc[0:2, "KROG"] = [1.00, 0.81, 0.81]
     # (this is valid in non-imbibition, but pyscal will correct it for all
     # curves)
     assert "0.1000000 0.0100000 0.8100000 0.0000000" in gasoil.SGOF()
@@ -440,12 +440,12 @@ def test_fast():
 
     # Provoke non-strict-monotone krow, in fast-mode
     # this slips through:
-    gasoil.table.loc[0:2, "krog"] = [1.00, 0.81, 0.81]
+    gasoil.table.loc[0:2, "KROG"] = [1.00, 0.81, 0.81]
     assert "0.1000000 0.0100000 0.8100000 0.0000000" in gasoil.SGOF()
     assert "0.2000000 0.0400000 0.8100000 0.0000000" in gasoil.SGOF()
     # not corrected:               ^^^^^^
 
-    gasoil.table.loc[0:2, "krg"] = [0.00, 0.01, 0.01]
+    gasoil.table.loc[0:2, "KRG"] = [0.00, 0.01, 0.01]
     assert "0.1000000 0.0100000" in gasoil.SGFN()
     assert "0.2000000 0.0100000" in gasoil.SGFN()
 
@@ -469,7 +469,7 @@ def test_roundoff():
     # Inject a custom dataframe that has occured in the wild,
     # and given monotonicity issues in GasOil.SGOF().
     gasoil.table = pd.DataFrame(
-        columns=["sg", "krg", "krog", "pc"],
+        columns=["SG", "KRG", "KROG", "PC"],
         data=[
             [0.02, 0, 0.19524045000000001, 0],
             [0.040000000000000001, 0, 0.19524044999999998, 0],
@@ -483,8 +483,8 @@ def test_roundoff():
             [1, 1, 0, 0],
         ],
     )
-    gasoil.table["sgn"] = gasoil.table["sg"]
-    gasoil.table["son"] = 1 - gasoil.table["sg"]
+    gasoil.table["SGN"] = gasoil.table["SG"]
+    gasoil.table["SON"] = 1 - gasoil.table["SG"]
     # If this value (as string) occurs, then we are victim of floating point truncation
     # in float_format=".7f":
     assert "0.1952404" not in gasoil.SGOF()
@@ -495,16 +495,16 @@ def test_roundoff():
 @pytest.mark.parametrize(
     "columnname, errorvalues",
     [
-        ("sg", [1, 0]),
-        ("sg", [0, 2]),
-        ("krg", [1, 0]),
-        ("krg", [0, 2]),
-        ("krog", [0, 1]),
-        ("krog", [2, 0]),
-        ("pc", [np.inf, 0]),
-        ("pc", [np.nan, 0]),
-        ("pc", [1, 2]),
-        ("pc", [0, 1]),
+        ("SG", [1, 0]),
+        ("SG", [0, 2]),
+        ("KRG", [1, 0]),
+        ("KRG", [0, 2]),
+        ("KROG", [0, 1]),
+        ("KROG", [2, 0]),
+        ("PC", [np.inf, 0]),
+        ("PC", [np.nan, 0]),
+        ("PC", [1, 2]),
+        ("PC", [0, 1]),
     ],
 )
 def test_selfcheck(columnname, errorvalues):
@@ -518,5 +518,5 @@ def test_selfcheck(columnname, errorvalues):
     gasoil.table[columnname] = errorvalues
     assert not gasoil.selfcheck()
     assert gasoil.SGOF() == ""
-    if not columnname == "krog":
+    if not columnname == "KROG":
         assert gasoil.SGFN() == ""

--- a/tests/test_gaswater.py
+++ b/tests/test_gaswater.py
@@ -28,27 +28,27 @@ def check_endpoints(gaswater, krwend, krwmax, krgend):
 
     # Check endpoints for gas curve:
     # krg at swl should be krgend:
-    assert float_df_checker(gaswater.gasoil.table, "sgn", 1.0, "krg", krgend)
-    assert float_df_checker(gaswater.gasoil.table, "sl", gaswater.swl, "krg", krgend)
+    assert float_df_checker(gaswater.gasoil.table, "SGN", 1.0, "KRG", krgend)
+    assert float_df_checker(gaswater.gasoil.table, "SL", gaswater.swl, "KRG", krgend)
     # krg at sgcr (sgn is zero there) should be zero:
-    assert float_df_checker(gaswater.gasoil.table, "sgn", 0.0, "krg", 0.0)
-    assert float_df_checker(gaswater.gasoil.table, "sl", 1 - gaswater.sgcr, "krg", 0.0)
+    assert float_df_checker(gaswater.gasoil.table, "SGN", 0.0, "KRG", 0.0)
+    assert float_df_checker(gaswater.gasoil.table, "SL", 1 - gaswater.sgcr, "KRG", 0.0)
 
     check_linear_sections(gaswater.gasoil)
     check_linear_sections(gaswater.wateroil)
 
     # Check endpoints for water curve: (np.isclose is only reliable around 1)
-    assert float_df_checker(gaswater.wateroil.table, "swn", 0.0, "krw", 0.0)
-    assert float_df_checker(gaswater.wateroil.table, "sw", gaswater.swcr, "krw", 0)
+    assert float_df_checker(gaswater.wateroil.table, "SWN", 0.0, "KRW", 0.0)
+    assert float_df_checker(gaswater.wateroil.table, "SW", gaswater.swcr, "KRW", 0)
 
     if gaswater.sgrw > swtol:
         # (hard to get it right when sgrw is less than h and close to zero)
         assert float_df_checker(
-            gaswater.wateroil.table, "sw", 1 - gaswater.sgrw, "krw", krwend
+            gaswater.wateroil.table, "SW", 1 - gaswater.sgrw, "KRW", krwend
         )
-        assert np.isclose(gaswater.wateroil.table["krw"].max(), krwmax)
+        assert np.isclose(gaswater.wateroil.table["KRW"].max(), krwmax)
     else:
-        assert np.isclose(gaswater.wateroil.table["krw"].max(), krwend)
+        assert np.isclose(gaswater.wateroil.table["KRW"].max(), krwend)
 
 
 def test_constructor():
@@ -102,8 +102,8 @@ def test_gaswater_corey1(nw, ng):
         # This happens for "invalid" input
         return
 
-    assert "krg" in gaswater.gasoil.table
-    assert "krw" in gaswater.wateroil.table
+    assert "KRG" in gaswater.gasoil.table
+    assert "KRW" in gaswater.wateroil.table
     assert isinstance(gaswater.wateroil.krwcomment, str)
     check_table(gaswater.wateroil.table)
     check_table(gaswater.gasoil.table)
@@ -126,8 +126,8 @@ def test_gaswater_let1(l, e, t, krwend, krwmax):
     except AssertionError:
         # This happens for negative values f.ex.
         return
-    assert "krg" in gaswater.gasoil.table
-    assert "krw" in gaswater.wateroil.table
+    assert "KRG" in gaswater.gasoil.table
+    assert "KRW" in gaswater.wateroil.table
     assert isinstance(gaswater.wateroil.krwcomment, str)
     check_table(gaswater.wateroil.table)
     check_table(gaswater.gasoil.table)
@@ -228,8 +228,8 @@ def test_gaswater_linear():
     check_linear_sections(gaswater.gasoil)
     assert len(gaswater.wateroil.table) == 2
     assert len(gaswater.gasoil.table) == 2
-    assert np.isclose(gaswater.wateroil.table["sw"].min(), 0.1)
-    assert np.isclose(gaswater.wateroil.table["sw"].max(), 1.0)
+    assert np.isclose(gaswater.wateroil.table["SW"].min(), 0.1)
+    assert np.isclose(gaswater.wateroil.table["SW"].max(), 1.0)
     # assert np.isclose(gaswater.crosspoint(), 0.55)
 
 
@@ -263,7 +263,7 @@ def test_crosspoint():
     assert np.isclose(gaswater.crosspoint(), 0.25)
 
     # Test warning/error situation:
-    del gaswater.wateroil.table["krw"]
+    del gaswater.wateroil.table["KRW"]
     assert gaswater.crosspoint() is None
 
 
@@ -277,7 +277,7 @@ def test_gaswater_pc():
     gaswater.add_corey_water()
     gaswater.add_corey_gas()
     gaswater.add_simple_J()
-    assert gaswater.wateroil.table["pc"].abs().sum() > 0
+    assert gaswater.wateroil.table["PC"].abs().sum() > 0
     swfn = gaswater.SWFN()
     assert "Simplified J-function" in swfn
     assert "0.1000000 0.0000000 0.23266" in swfn  # this is the first row.

--- a/tests/test_scalrecommendation.py
+++ b/tests/test_scalrecommendation.py
@@ -213,9 +213,9 @@ def test_interpolation(param_wo, param_go):
     rec.add_simple_J()  # Add default pc curve
 
     # Check that added pc curve is non-zero
-    assert sum(rec.low.wateroil.table["pc"])
-    assert sum(rec.base.wateroil.table["pc"])
-    assert sum(rec.high.wateroil.table["pc"])
+    assert sum(rec.low.wateroil.table["PC"])
+    assert sum(rec.base.wateroil.table["PC"])
+    assert sum(rec.high.wateroil.table["PC"])
 
     try:
         interpolant = rec.interpolate(param_wo, param_go, h=0.1)
@@ -232,7 +232,7 @@ def test_interpolation(param_wo, param_go):
     assert len(interpolant.wateroil.SWOF()) > 100
     assert interpolant.threephaseconsistency()
 
-    assert sum(interpolant.wateroil.table["pc"])
+    assert sum(interpolant.wateroil.table["PC"])
 
 
 def test_boundary_cases():
@@ -245,8 +245,8 @@ def test_boundary_cases():
     )
     assert rec.type == WaterOilGas
 
-    wo_cols = ["sw", "krw", "krow"]  # no Pc in this test data
-    go_cols = ["sg", "krg", "krog"]
+    wo_cols = ["SW", "KRW", "KROW"]  # no Pc in this test data
+    go_cols = ["SG", "KRG", "KROG"]
     assert (
         rec.interpolate(0)
         .wateroil.table[wo_cols]

--- a/tests/test_slgof.py
+++ b/tests/test_slgof.py
@@ -17,14 +17,14 @@ def check_table(dframe):
     """Check sanity of important columns"""
     assert not dframe.empty
     assert not dframe.isnull().values.any()
-    assert dframe["sl"].is_monotonic
-    assert (dframe["sl"] >= 0.0).all()
-    assert (dframe["sl"] <= 1.0).all()
+    assert dframe["SL"].is_monotonic
+    assert (dframe["SL"] >= 0.0).all()
+    assert (dframe["SL"] <= 1.0).all()
     # Increasing, but not monotonically for slgof
-    assert (dframe["krog"].diff().dropna() > -EPSILON).all()
-    assert dframe["krg"].is_monotonic_decreasing
-    if "pc" in dframe:
-        assert dframe["pc"].is_monotonic_decreasing
+    assert (dframe["KROG"].diff().dropna() > -EPSILON).all()
+    assert dframe["KRG"].is_monotonic_decreasing
+    if "PC" in dframe:
+        assert dframe["PC"].is_monotonic_decreasing
 
 
 @settings(deadline=1000)
@@ -44,18 +44,18 @@ def test_slgof(swl, sorg, sgcr):
     assert wog.selfcheck()
 
     slgof = wog.gasoil.slgof_df()
-    assert "sl" in slgof
-    assert "krg" in slgof
-    assert "krog" in slgof
+    assert "SL" in slgof
+    assert "KRG" in slgof
+    assert "KROG" in slgof
     assert not slgof.empty
 
     check_table(slgof)
     sat_table_str_ok(wog.SLGOF())
 
     # Requirements from E100 manual:
-    assert np.isclose(slgof["sl"].values[0], wog.gasoil.swl + wog.gasoil.sorg)
-    assert np.isclose(slgof["krg"].values[-1], 0)
-    assert np.isclose(slgof["krog"].values[0], 0)
+    assert np.isclose(slgof["SL"].values[0], wog.gasoil.swl + wog.gasoil.sorg)
+    assert np.isclose(slgof["KRG"].values[-1], 0)
+    assert np.isclose(slgof["KROG"].values[0], 0)
 
 
 @pytest.mark.parametrize(
@@ -84,8 +84,8 @@ def test_numerical_problems(swl, sorg, sgcr):
     gasoil.add_corey_oil()
     assert gasoil.selfcheck()
     slgof = gasoil.slgof_df()
-    assert np.isclose(slgof["sl"].values[0], gasoil.swl + gasoil.sorg)
-    assert np.isclose(slgof["sl"].values[-1], 1.0)
+    assert np.isclose(slgof["SL"].values[0], gasoil.swl + gasoil.sorg)
+    assert np.isclose(slgof["SL"].values[-1], 1.0)
     check_table(slgof)
 
 
@@ -105,9 +105,9 @@ def test_slgof_hypo(swl, sorg, sgcr, h):
     slgof = gasoil.slgof_df()
     check_table(slgof)
     # Eclipse 100 requirement from manual:
-    assert np.isclose(slgof["sl"].values[0], gasoil.swl + gasoil.sorg)
+    assert np.isclose(slgof["SL"].values[0], gasoil.swl + gasoil.sorg)
     # Eclipse 100 requirement from manual:
-    assert np.isclose(slgof["sl"].values[-1], 1.0)
+    assert np.isclose(slgof["SL"].values[-1], 1.0)
     slgof_str = gasoil.SLGOF()
     assert isinstance(slgof_str, str)
     assert slgof_str

--- a/tests/test_utils_interpolation.py
+++ b/tests/test_utils_interpolation.py
@@ -74,8 +74,8 @@ def test_normalize_pc(swirr, dswl):
     """Test that we can normalize a pc curve"""
     wateroil = WaterOil(swirr=swirr, swl=swirr + dswl)
     wateroil.add_simple_J()
-    pc_max = wateroil.table["pc"].max()
-    pc_min = wateroil.table["pc"].min()
+    pc_max = wateroil.table["PC"].max()
+    pc_min = wateroil.table["PC"].min()
 
     pc_fn = normalize_pc(wateroil)
     assert np.isclose(pc_fn(0), pc_max)
@@ -149,7 +149,7 @@ def test_normalize_nonlinpart_wo():
     assert np.isclose(kron(1), 0.8)
 
     # So fix endpoints!
-    wateroil.swl = wateroil.table["sw"].min()
+    wateroil.swl = wateroil.table["SW"].min()
     wateroil.swcr = wateroil.estimate_swcr()
     wateroil.sorw = wateroil.estimate_sorw()
     # Try again
@@ -273,16 +273,16 @@ def test_interpolate_wo(
 
     # Distances between low and interpolants:
     dists = [
-        (wo_low.table - interp.table)[["krw", "krow"]].sum().sum() for interp in ips
+        (wo_low.table - interp.table)[["KRW", "KROW"]].sum().sum() for interp in ips
     ]
     assert np.isclose(dists[0], 0)
 
     # Distance between high and the last interpolant
-    assert (wo_high.table - ips[-1].table)[["krw", "krow"]].sum().sum() < 0.01
+    assert (wo_high.table - ips[-1].table)[["KRW", "KROW"]].sum().sum() < 0.01
 
     # Distances between low and interpolants:
     dists = [
-        (wo_low.table - interp.table)[["krw", "krow"]].sum().sum() for interp in ips
+        (wo_low.table - interp.table)[["KRW", "KROW"]].sum().sum() for interp in ips
     ]
     print(
         "Interpolation, mean: {}, min: {}, max: {}, std: {} ip-par-dist: {}".format(
@@ -349,14 +349,14 @@ def test_interpolate_wo_pc(swl, dswcr, dswlhigh, sorw, a_l, a_h, b_l, b_h):
         assert 0 < wo_ip.crosspoint() < 1
 
     # Distances between low and interpolants:
-    dists = [(wo_low.table - interp.table)[["pc"]].sum().sum() for interp in ips]
+    dists = [(wo_low.table - interp.table)[["PC"]].sum().sum() for interp in ips]
     assert np.isclose(dists[0], 0)
 
     # Distance between high and the last interpolant
-    assert (wo_high.table - ips[-1].table)[["pc"]].sum().sum() < 0.01
+    assert (wo_high.table - ips[-1].table)[["PC"]].sum().sum() < 0.01
 
     # Distances between low and interpolants:
-    dists = [(wo_low.table - interp.table)[["pc"]].sum().sum() for interp in ips]
+    dists = [(wo_low.table - interp.table)[["PC"]].sum().sum() for interp in ips]
     print(
         "Interpolation, mean: {}, min: {}, max: {}, std: {} ip-par-dist: {}".format(
             np.mean(dists), min(dists), max(dists), np.std(np.diff(dists[1:])), ip_dist
@@ -492,7 +492,7 @@ def test_normalize_nonlinpart_go():
     assert not np.isclose(krgn(1), 0.6)
 
     # So fix endpoints!
-    gasoil.swl = 1 - gasoil.table["sg"].max()
+    gasoil.swl = 1 - gasoil.table["SG"].max()
     gasoil.sgcr = gasoil.estimate_sgcr()
     gasoil.sorg = gasoil.estimate_sorg()
     # Try again
@@ -517,10 +517,10 @@ def test_ip_wo_kroend():
     wo_ip = interpolate_wo(wo_low, wo_high, 0.5)
 
     # kroend at mean swl:
-    assert float_df_checker(wo_ip.table, "sw", 0.01, "krow", (0.6 + 0.7) / 2.0)
+    assert float_df_checker(wo_ip.table, "SW", 0.01, "KROW", (0.6 + 0.7) / 2.0)
 
-    assert float_df_checker(wo_ip.table, "sw", 1, "krw", 0.71)
-    assert float_df_checker(wo_ip.table, "sw", 1 - 0.15, "krw", 0.5)
+    assert float_df_checker(wo_ip.table, "SW", 1, "KRW", 0.71)
+    assert float_df_checker(wo_ip.table, "SW", 1 - 0.15, "KRW", 0.5)
 
 
 def test_ip_go_kroend():
@@ -537,15 +537,15 @@ def test_ip_go_kroend():
     go_ip = interpolate_go(go_low, go_high, 0.5)
 
     # kroend at sg zero:
-    assert float_df_checker(go_ip.table, "sg", 0.0, "krog", (0.6 + 0.7) / 2.0)
+    assert float_df_checker(go_ip.table, "SG", 0.0, "KROG", (0.6 + 0.7) / 2.0)
 
     assert np.isclose(go_ip.swl, 0.01)
     assert np.isclose(go_ip.sorg, 0.15)
 
     # krgmax at 1 - swl:
-    assert float_df_checker(go_ip.table, "sg", 1 - go_ip.swl, "krg", 0.71)
+    assert float_df_checker(go_ip.table, "SG", 1 - go_ip.swl, "KRG", 0.71)
     # krgend at 1 - swl - sorg
-    assert float_df_checker(go_ip.table, "sg", 1 - go_ip.swl - go_ip.sorg, "krg", 0.5)
+    assert float_df_checker(go_ip.table, "SG", 1 - go_ip.swl - go_ip.sorg, "KRG", 0.5)
 
     # If krgendanchor is None, then krgmax should be irrelevant
     go_low = GasOil(swl=0, sgcr=0.1, sorg=0.2, krgendanchor="")
@@ -562,7 +562,7 @@ def test_ip_go_kroend():
     # Interpolate to midpoint between the curves above
     go_ip = interpolate_go(go_low, go_high, 0.5, h=0.1)
 
-    assert float_df_checker(go_ip.table, "sg", 0.0, "krog", (0.6 + 0.7) / 2.0)
+    assert float_df_checker(go_ip.table, "SG", 0.0, "KROG", (0.6 + 0.7) / 2.0)
 
     # Activate these line to see a bug, interpolation_go
     # does not honor krgendanchorA:
@@ -573,7 +573,7 @@ def test_ip_go_kroend():
     # plt.show()
 
     # krgmax is irrelevant, krgend is used here:
-    assert float_df_checker(go_ip.table, "sg", 1 - 0.01, "krg", 0.5)
+    assert float_df_checker(go_ip.table, "SG", 1 - 0.01, "KRG", 0.5)
 
     # Also check that estimated new sgcr is between the inputs:
     assert 0.05 <= go_ip.estimate_sgcr() <= 0.1
@@ -590,17 +590,17 @@ def test_ip_go_kroend():
     # Interpolate to midpoint between the curves above
     go_ip = interpolate_go(go_low, go_high, 0.5)
 
-    assert float_df_checker(go_ip.table, "sg", 0.0, "krog", (0.6 + 0.7) / 2.0)
+    assert float_df_checker(go_ip.table, "SG", 0.0, "KROG", (0.6 + 0.7) / 2.0)
 
     # max(krg) is here avg of krgmax and krgend from the differnt tables:
-    assert float_df_checker(go_ip.table, "sg", 1 - 0.01, "krg", 0.6)
+    assert float_df_checker(go_ip.table, "SG", 1 - 0.01, "KRG", 0.6)
 
     # krgend at 1 - swl - sorg, non-trivial expression, so a numerical
     # value is used here in the test:
-    assert float_df_checker(go_ip.table, "sg", 1 - 0.01 - 0.15, "krg", 0.4491271)
+    assert float_df_checker(go_ip.table, "SG", 1 - 0.01 - 0.15, "KRG", 0.4491271)
 
     # krog-zero at 1 - swl - sorg:
-    assert float_df_checker(go_ip.table, "sg", 1 - 0.01 - 0.15, "krog", 0)
+    assert float_df_checker(go_ip.table, "SG", 1 - 0.01 - 0.15, "KROG", 0)
 
 
 @settings(max_examples=50, deadline=5000)
@@ -678,7 +678,7 @@ def test_interpolate_go(
 
     # Distances between low and interpolants:
     dists = [
-        (go_low.table - interp.table)[["krg", "krog"]].sum().sum() for interp in ips
+        (go_low.table - interp.table)[["KRG", "KROG"]].sum().sum() for interp in ips
     ]
     print(
         "Interpolation, mean: {}, min: {}, max: {}, std: {} ip-par-dist: {}".format(
@@ -714,7 +714,7 @@ def test_interpolations_go_fromtable():
     was underestimated in interpolations following add_fromtable().
     """
     base = pd.DataFrame(
-        columns=["Sg", "krg", "krog"],
+        columns=["SG", "KRG", "KROG"],
         data=[
             [0.0, 0.0, 1.0],
             [0.1, 0.0, 1.0],
@@ -726,7 +726,7 @@ def test_interpolations_go_fromtable():
         ],
     )
     opt = pd.DataFrame(
-        columns=["Sg", "krg", "krog"],
+        columns=["SG", "KRG", "KROG"],
         data=[
             [0.0, 0.0, 1.0],
             [0.1, 0.0, 1.0],
@@ -757,7 +757,7 @@ def test_interpolations_wo_fromtable():
     Pyscal 0.6.1 and earlier fails this test sorw.
     """
     base = pd.DataFrame(
-        columns=["Sw", "krw", "krow"],
+        columns=["SW", "KRW", "KROW"],
         data=[
             [0.0, 0.0, 1.0],
             [0.1, 0.0, 1.0],
@@ -769,7 +769,7 @@ def test_interpolations_wo_fromtable():
         ],
     )
     opt = pd.DataFrame(
-        columns=["Sw", "krw", "krow"],
+        columns=["SW", "KRW", "KROW"],
         data=[
             [0.0, 0.0, 1.0],
             [0.1, 0.0, 1.0],

--- a/tests/test_utils_monotonicity.py
+++ b/tests/test_utils_monotonicity.py
@@ -50,18 +50,18 @@ def test_df2str_monotone():
     )
 
     # For strict monotonicity we will introduce negativity:
-    dframe = pd.DataFrame(data=[0.00001, 0.0, 0.0, 0.0], columns=["pc"])
+    dframe = pd.DataFrame(data=[0.00001, 0.0, 0.0, 0.0], columns=["PC"])
     assert (
-        df2str(dframe, monotonicity={"pc": {"sign": -1}})
+        df2str(dframe, monotonicity={"PC": {"sign": -1}})
         == "0.0000100\n0.0000000\n-0.0000001\n-0.0000002\n"
     )
 
     # Actual data that has occured:
     dframe = pd.DataFrame(
-        data=[0.0000027, 0.0000026, 0.0000024, 0.0000024, 0.0000017], columns=["pc"]
+        data=[0.0000027, 0.0000026, 0.0000024, 0.0000024, 0.0000017], columns=["PC"]
     )
     assert (
-        df2str(dframe, monotonicity={"pc": {"sign": -1}})
+        df2str(dframe, monotonicity={"PC": {"sign": -1}})
         == "0.0000027\n0.0000026\n0.0000024\n0.0000023\n0.0000017\n"
     )
 
@@ -252,7 +252,7 @@ def test_df2str_nonstrict_monotonicity_digits1(series, monotonicity, expected):
         ([0, 0.5, 1], {0: {"sign": -1, "lower": 0, "upper": 1}}),
         ([0, 1], {1: "foo"}),  # not a dict of dict
         ([0, 1], {0: {}}),  # sign is required
-        ([0, 1], {0: {"sgn": 1}}),  # sign is required
+        ([0, 1], {0: {"SGN": 1}}),  # sign is required
         ([0, 1], {0: {"sign": 2}}),  # sign have abs = 1
         ([0, 1], {0: {"sign": 1, "lower": "a"}}),
         ([0, 1], {0: {"sign": 1, "lower": 2}}),

--- a/tests/test_wateroil.py
+++ b/tests/test_wateroil.py
@@ -30,21 +30,21 @@ def check_endpoints(wateroil, krwend, krwmax, kroend):
     # Check endpoints for oil curve:
     # krow at swcr should be kroend:
     if wateroil.swcr > wateroil.swl + swtol:
-        assert float_df_checker(wateroil.table, "son", 1.0, "krow", kroend)
+        assert float_df_checker(wateroil.table, "SON", 1.0, "KROW", kroend)
     # krow at sorw should be zero:
-    assert float_df_checker(wateroil.table, "son", 0.0, "krow", 0.0)
-    assert np.isclose(wateroil.table["krow"].max(), kroend)
+    assert float_df_checker(wateroil.table, "SON", 0.0, "KROW", 0.0)
+    assert np.isclose(wateroil.table["KROW"].max(), kroend)
 
     # Check endpoints for water curve: (np.isclose is only reliable around 1)
-    assert float_df_checker(wateroil.table, "swn", 0.0, "krw", 0.0)
-    assert float_df_checker(wateroil.table, "sw", wateroil.swcr, "krw", 0)
+    assert float_df_checker(wateroil.table, "SWN", 0.0, "KRW", 0.0)
+    assert float_df_checker(wateroil.table, "SW", wateroil.swcr, "KRW", 0)
 
     if wateroil.sorw > swtol:
         # (hard to get it right when sorw is less than h and close to zero)
-        assert float_df_checker(wateroil.table, "sw", 1 - wateroil.sorw, "krw", krwend)
-        assert np.isclose(wateroil.table["krw"].max(), krwmax)
+        assert float_df_checker(wateroil.table, "SW", 1 - wateroil.sorw, "KRW", krwend)
+        assert np.isclose(wateroil.table["KRW"].max(), krwmax)
     else:
-        assert np.isclose(wateroil.table["krw"].max(), krwend)
+        assert np.isclose(wateroil.table["KRW"].max(), krwend)
 
 
 @given(st.text())
@@ -70,8 +70,8 @@ def test_wateroil_corey1(nw, now):
         # This happens for "invalid" input
         return
 
-    assert "krow" in wateroil.table
-    assert "krw" in wateroil.table
+    assert "KROW" in wateroil.table
+    assert "KRW" in wateroil.table
     assert isinstance(wateroil.krwcomment, str)
     check_table(wateroil.table)
     check_linear_sections(wateroil)
@@ -90,8 +90,8 @@ def test_wateroil_let1(l, e, t, krwend, krwmax):
     except AssertionError:
         # This happens for negative values f.ex.
         return
-    assert "krow" in wateroil.table
-    assert "krw" in wateroil.table
+    assert "KROW" in wateroil.table
+    assert "KRW" in wateroil.table
     assert isinstance(wateroil.krwcomment, str)
     check_table(wateroil.table)
     check_linear_sections(wateroil)
@@ -146,7 +146,7 @@ def test_fast():
     assert "-- krw = krow @ sw=0.5" in wateroil.SWOF()
 
     # Provoke non-strict-monotone krow:
-    wateroil.table.loc[0:2, "krow"] = [1.00, 0.81, 0.81]
+    wateroil.table.loc[0:2, "KROW"] = [1.00, 0.81, 0.81]
     # (this is valid in non-imbibition, but pyscal will correct it for all
     # curves)
     assert "0.1000000 0.0100000 0.8100000 0.0000000" in wateroil.SWOF()
@@ -162,12 +162,12 @@ def test_fast():
 
     # Provoke non-strict-monotone krow, in fast-mode
     # this slips through:
-    wateroil.table.loc[0:2, "krow"] = [1.00, 0.81, 0.81]
+    wateroil.table.loc[0:2, "KROW"] = [1.00, 0.81, 0.81]
     assert "0.1000000 0.0100000 0.8100000 0.0000000" in wateroil.SWOF()
     assert "0.2000000 0.0400000 0.8100000 0.0000000" in wateroil.SWOF()
     # not corrected:               ^^^^^^
 
-    wateroil.table.loc[0:2, "krw"] = [0.00, 0.01, 0.01]
+    wateroil.table.loc[0:2, "KRW"] = [0.00, 0.01, 0.01]
     assert "0.1000000 0.0100000" in wateroil.SWFN()
     assert "0.2000000 0.0100000" in wateroil.SWFN()
 
@@ -224,8 +224,8 @@ def test_wateroil_linear():
     check_table(wateroil.table)
     check_linear_sections(wateroil)
     assert len(wateroil.table) == 2
-    assert np.isclose(wateroil.table["sw"].min(), 0.1)
-    assert np.isclose(wateroil.table["sw"].max(), 1.0)
+    assert np.isclose(wateroil.table["SW"].min(), 0.1)
+    assert np.isclose(wateroil.table["SW"].max(), 1.0)
     assert np.isclose(wateroil.crosspoint(), 0.55)
 
 
@@ -294,16 +294,16 @@ def test_nexus():
 @pytest.mark.parametrize(
     "columnname, errorvalues",
     [
-        ("sw", [1, 0]),
-        ("sw", [0, 2]),
-        ("krw", [1, 0]),
-        ("krw", [0, 2]),
-        ("krow", [0, 1]),
-        ("krow", [2, 0]),
-        ("pc", [np.inf, 0]),
-        ("pc", [np.nan, 0]),
-        ("pc", [1, 2]),
-        ("pc", [0, 1]),
+        ("SW", [1, 0]),
+        ("SW", [0, 2]),
+        ("KRW", [1, 0]),
+        ("KRW", [0, 2]),
+        ("KROW", [0, 1]),
+        ("KROW", [2, 0]),
+        ("PC", [np.inf, 0]),
+        ("PC", [np.nan, 0]),
+        ("PC", [1, 2]),
+        ("PC", [0, 1]),
     ],
 )
 def test_selfcheck(columnname, errorvalues):
@@ -317,5 +317,5 @@ def test_selfcheck(columnname, errorvalues):
     wateroil.table[columnname] = errorvalues
     assert not wateroil.selfcheck()
     assert wateroil.SWOF() == ""
-    if not columnname == "krow":
+    if not columnname == "KROW":
         assert wateroil.SWFN() == ""

--- a/tests/test_wateroil_pc.py
+++ b/tests/test_wateroil_pc.py
@@ -27,12 +27,12 @@ def test_simple_j():
     # Zero gravity:
     wateroil = WaterOil(swl=0.01)
     wateroil.add_simple_J(g=0)
-    assert wateroil.table.pc.unique() == 0.0
+    assert wateroil.table["PC"].unique() == 0.0
 
     # This should give back Sw:
     # This ensures that density and gravity scaling is correct
     wateroil.add_simple_J(a=1, b=1, poro_ref=1, perm_ref=1, drho=1000, g=100)
-    assert (wateroil.table["pc"] - wateroil.table["sw"]).sum() < 0.00001
+    assert (wateroil.table["PC"] - wateroil.table["SW"]).sum() < 0.00001
     # (check_table() will fail on this, when b > 0)
 
     # Some values seen in real life:
@@ -64,14 +64,14 @@ def test_simple_j_petro():
 
     # Zero gravity:
     wateroil.add_simple_J_petro(a=1, b=-2, g=0)
-    assert wateroil.table.pc.unique() == 0.0
+    assert wateroil.table["PC"].unique() == 0.0
 
     # Numerical test from sample numbers calculated independently in different tool:
     wateroil = WaterOil(swl=0.05, h=0.025)
     wateroil.add_simple_J_petro(
         a=1.45, b=-0.285, drho=143, g=9.81, perm_ref=15, poro_ref=0.27
     )
-    float_df_checker(wateroil.table, "sw", 0.1, "pc", 22.36746)
+    float_df_checker(wateroil.table, "SW", 0.1, "PC", 22.36746)
     assert "Simplified" in wateroil.pccomment
     assert "etrophysic" in wateroil.pccomment
     wateroil.add_corey_oil()
@@ -125,9 +125,9 @@ def test_normalized_j(caplog):
     # NB: Prior implementation created Pc in atm, we create in bar
     bar_to_atm = 1.0 / 1.01325
     wateroil.add_normalized_J(a=0.22, b=-0.5, perm=100, poro=0.2, sigma_costau=30)
-    float_df_checker(wateroil.table, "sw", 0.1, "pc", 2.039969 * bar_to_atm)
-    float_df_checker(wateroil.table, "sw", 0.6, "pc", 0.056666 * bar_to_atm)
-    float_df_checker(wateroil.table, "sw", 1.0, "pc", 0.02040 * bar_to_atm)
+    float_df_checker(wateroil.table, "SW", 0.1, "PC", 2.039969 * bar_to_atm)
+    float_df_checker(wateroil.table, "SW", 0.6, "PC", 0.056666 * bar_to_atm)
+    float_df_checker(wateroil.table, "SW", 1.0, "PC", 0.02040 * bar_to_atm)
 
     wateroil = WaterOil(swirr=0.1, swl=0.11, h=0.1)
     wateroil.add_normalized_J(a=0.5, b=-0.001, poro=0.2, perm=10, sigma_costau=30)
@@ -176,20 +176,20 @@ def test_let_pc_pd():
     """Test LET formulation for primary drainage capillary pressure"""
     wateroil = WaterOil(swirr=0.1)
     wateroil.add_LET_pc_pd(Lp=1, Ep=1, Tp=1, Lt=1, Et=1, Tt=1, Pcmax=10, Pct=5)
-    assert np.isclose(wateroil.table["pc"].max(), 10)
-    assert np.isclose(wateroil.table["pc"].min(), 0)
+    assert np.isclose(wateroil.table["PC"].max(), 10)
+    assert np.isclose(wateroil.table["PC"].min(), 0)
     # (everything is linear)
 
     wateroil.add_LET_pc_pd(Lp=10, Ep=10, Tp=10, Lt=10, Et=10, Tt=10, Pcmax=10, Pct=5)
-    assert np.isclose(wateroil.table["pc"].max(), 10)
-    assert np.isclose(wateroil.table["pc"].min(), 0)
+    assert np.isclose(wateroil.table["PC"].max(), 10)
+    assert np.isclose(wateroil.table["PC"].min(), 0)
     # On a plot, you can see a kink at Pc=5.
     # wateroil.plotpc()
 
     wateroil = WaterOil(swirr=0.1, sorw=0.4)
     wateroil.add_LET_pc_pd(Lp=10, Ep=10, Tp=10, Lt=10, Et=10, Tt=10, Pcmax=5, Pct=2)
-    assert np.isclose(wateroil.table["pc"].max(), 5)
-    assert np.isclose(wateroil.table["pc"].min(), 0)
+    assert np.isclose(wateroil.table["PC"].max(), 5)
+    assert np.isclose(wateroil.table["PC"].min(), 0)
     # On plot: hard-to-see kink at Pc=2. .
     # wateroil.plotpc()
     wateroil.add_corey_water()
@@ -203,18 +203,18 @@ def test_let_pc_imb():
     wateroil.add_LET_pc_imb(
         Ls=1, Es=1, Ts=1, Lf=1, Ef=1, Tf=1, Pcmax=10, Pcmin=-10, Pct=3
     )
-    assert np.isclose(wateroil.table["pc"].max(), 10)
-    assert np.isclose(wateroil.table["pc"].min(), -10)
+    assert np.isclose(wateroil.table["PC"].max(), 10)
+    assert np.isclose(wateroil.table["PC"].min(), -10)
 
     wateroil = WaterOil(swirr=0.1)
     wateroil.add_LET_pc_imb(Ls=5, Es=5, Ts=5, Lf=5, Ef=5, Tf=5, Pcmax=5, Pcmin=1, Pct=4)
-    assert np.isclose(wateroil.table["pc"].max(), 5)
-    assert np.isclose(wateroil.table["pc"].min(), 1)
+    assert np.isclose(wateroil.table["PC"].max(), 5)
+    assert np.isclose(wateroil.table["PC"].min(), 1)
 
     wateroil = WaterOil(swirr=0.1, sorw=0.3)
     wateroil.add_LET_pc_imb(Ls=5, Es=5, Ts=5, Lf=5, Ef=5, Tf=5, Pcmax=5, Pcmin=1, Pct=4)
-    assert np.isclose(wateroil.table["pc"].max(), 5)
-    assert np.isclose(wateroil.table["pc"].min(), 1)
+    assert np.isclose(wateroil.table["PC"].max(), 5)
+    assert np.isclose(wateroil.table["PC"].min(), 1)
     wateroil.add_corey_water()
     wateroil.add_corey_oil()
     sat_table_str_ok(wateroil.SWOF())

--- a/tests/test_wateroil_saturation.py
+++ b/tests/test_wateroil_saturation.py
@@ -41,27 +41,27 @@ def test_wateroil_normalization(swirr, swl, swcr, sorw, h, tag):
     assert not wateroil.table.isnull().values.any()
 
     # Check that son is 1 at swl:
-    assert float_df_checker(wateroil.table, "sw", wateroil.swl, "son", 1)
+    assert float_df_checker(wateroil.table, "SW", wateroil.swl, "SON", 1)
 
     # Check that son is 0 at sorw:
     if wateroil.sorw > h:
-        assert float_df_checker(wateroil.table, "sw", 1 - wateroil.sorw, "son", 0)
+        assert float_df_checker(wateroil.table, "SW", 1 - wateroil.sorw, "SON", 0)
 
     # Check that swn is 0 at swcr:
-    assert float_df_checker(wateroil.table, "sw", wateroil.swcr, "swn", 0)
+    assert float_df_checker(wateroil.table, "SW", wateroil.swcr, "SWN", 0)
     # Check that swn is 1 at 1 - sorw
     if wateroil.sorw > 1 / SWINTEGERS:
-        assert float_df_checker(wateroil.table, "sw", 1 - wateroil.sorw, "swn", 1)
+        assert float_df_checker(wateroil.table, "SW", 1 - wateroil.sorw, "SWN", 1)
 
     # Check that swnpc is 0 at swirr and 1 at 1:
     if wateroil.swirr >= wateroil.swl + h:
-        assert float_df_checker(wateroil.table, "sw", wateroil.swirr, "swnpc", 0)
+        assert float_df_checker(wateroil.table, "SW", wateroil.swirr, "SWNPC", 0)
     else:
         # Let this go, when swirr is too close to swl. We
         # are not guaranteed to have sw=swirr present
         pass
 
-    assert float_df_checker(wateroil.table, "sw", 1.0, "swnpc", 1)
+    assert float_df_checker(wateroil.table, "SW", 1.0, "SWNPC", 1)
 
 
 @given(st.floats(min_value=0, max_value=1))


### PR DESCRIPTION
This is for consistency with other related tools, which tend to use upper case
for column names as this, e.g. fmu-ensemble, ecl2df, fmu-tools.