### PR TITLE
Remove deprecated functionality for monotonicity

### DIFF
--- a/pyscal/utils/monotonocity.py
+++ b/pyscal/utils/monotonocity.py
@@ -278,15 +278,3 @@ def validate_monotonocity_arg(monotonocity, dframe_colnames):
                 raise ValueError(
                     "allowzero in monotonocity argument must be True/False"
                 )
-
-
-def remap_deprecated_monotonocity(monotone_column, monotone_direction):
-    """Remove this function around pyscal 0.9"""
-    signs = {"1": 1, "+1": 1, "inc": 1, "-1": -1, "dec": -1}
-    if monotone_column is not None and monotone_direction is None:
-        return {monotone_column: {"sign": -1}}
-    if monotone_column is not None and monotone_direction is not None:
-        if str(monotone_direction) not in signs:
-            raise ValueError("Invalid monotone_direction {}".format(monotone_direction))
-        return {monotone_column: {"sign": signs[str(monotone_direction)]}}
-    return {}

--- a/pyscal/utils/string.py
+++ b/pyscal/utils/string.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from .monotonocity import modify_dframe_monotonocity, remap_deprecated_monotonocity
+from .monotonocity import modify_dframe_monotonocity
 
 logger = logging.getLogger(__name__)
 
@@ -43,22 +43,8 @@ def df2str(
             "sign" (-1 or +1 integer) for direction,  "upper" and "lower" for
             lower and upper limits (non-strict monotonocity is allowed at
             these upper and lower limits).
-        monotone_columns (list of str): column names for which strict
-            monotonocity must be preserved in output. Deprecated.
-        monotone_directions (list of str): Direction of monotonocity, increasing
-            or decreasing, allowed values are '-1', '1', 'inc' or 'dec'. If
-            multiple columns, specify for each. Deprecated.
     """
     float_format = "%1." + str(digits) + "f"
-
-    if monotonocity is not None and monotone_column is not None:
-        raise ValueError("Do not mix new and deprecated API")
-
-    if monotonocity is None and monotone_column is not None:
-        logger.warning("monotone_column is deprecated, use monotonocity")
-        monotonocity = remap_deprecated_monotonocity(
-            monotone_column, monotone_direction
-        )
 
     if monotonocity is not None:
         dframe = modify_dframe_monotonocity(dframe, monotonocity, digits)

--- a/tests/test_utils_monotonocity.py
+++ b/tests/test_utils_monotonocity.py
@@ -25,54 +25,34 @@ def test_df2str_monotone():
     # A constant nonzero column, makes no sense as capillary pressure
     # but still we ensure it runs in eclipse:
     assert (
-        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotone_column=0)
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": -1}})
         == "1.00\n0.99\n0.98\n"
     )
     assert (
-        df2str(
-            pd.DataFrame(data=[1, 1, 1]),
-            digits=2,
-            monotone_column=0,
-            monotone_direction=-1,
-        )
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": -1}})
         == "1.00\n0.99\n0.98\n"
     )
     assert (
-        df2str(
-            pd.DataFrame(data=[1, 1, 1]),
-            digits=2,
-            monotone_column=0,
-            monotone_direction="dec",
-        )
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": -1}})
         == "1.00\n0.99\n0.98\n"
     )
     assert (
-        df2str(
-            pd.DataFrame(data=[1, 1, 1]),
-            digits=2,
-            monotone_column=0,
-            monotone_direction=1,
-        )
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": 1}})
         == "1.00\n1.01\n1.02\n"
     )
     assert (
-        df2str(
-            pd.DataFrame(data=[1, 1, 1]),
-            digits=2,
-            monotone_column=0,
-            monotone_direction="inc",
-        )
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": 1}})
         == "1.00\n1.01\n1.02\n"
     )
     assert (
-        df2str(pd.DataFrame(data=[1, 1, 1]), digits=7, monotone_column=0)
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=7, monotonocity={0: {"sign": -1}})
         == "1.0000000\n0.9999999\n0.9999998\n"
     )
 
     # For strict monotonicity we will introduce negativity:
     dframe = pd.DataFrame(data=[0.00001, 0.0, 0.0, 0.0], columns=["pc"])
     assert (
-        df2str(dframe, monotone_column="pc")
+        df2str(dframe, monotonocity={"pc": {"sign": -1}})
         == "0.0000100\n0.0000000\n-0.0000001\n-0.0000002\n"
     )
 
@@ -81,7 +61,7 @@ def test_df2str_monotone():
         data=[0.0000027, 0.0000026, 0.0000024, 0.0000024, 0.0000017], columns=["pc"]
     )
     assert (
-        df2str(dframe, monotone_column="pc")
+        df2str(dframe, monotonocity={"pc": {"sign": -1}})
         == "0.0000027\n0.0000026\n0.0000024\n0.0000023\n0.0000017\n"
     )
 


### PR DESCRIPTION
This is an API break, but very unlikely that anyone except pyscal
itself is using it