### PR TITLE
Change monotonocity to monotonicity everywhere

### DIFF
--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -702,7 +702,7 @@ class GasOil(object):
         )
         string += df2str(
             self.table[["sg", "krg", "krog", "pc"]],
-            monotonocity={
+            monotonicity={
                 "krog": {"sign": -1, "lower": 0, "upper": 1},
                 "krg": {"sign": 1, "lower": 0, "upper": 1},
                 "pc": {"sign": 1, "allowzero": True},
@@ -798,7 +798,7 @@ class GasOil(object):
         )
         string += df2str(
             self.slgof_df(),
-            monotonocity={
+            monotonicity={
                 "krog": {"sign": 1, "lower": 0, "upper": 1},
                 "krg": {"sign": -1, "lower": 0, "upper": 1},
                 "pc": {"sign": -1, "allowzero": True},
@@ -868,7 +868,7 @@ class GasOil(object):
         )
         string += df2str(
             self.table[["sg", "krg", "pc"]],
-            monotonocity={
+            monotonicity={
                 "krg": {"sign": 1, "lower": 0, "upper": 1},
                 "pc": {"sign": 1, "allowzero": True},
             }
@@ -921,7 +921,7 @@ class GasOil(object):
         )
         string += df2str(
             self.table[["sg", "krg", "krog", "pc"]],
-            monotonocity={
+            monotonicity={
                 "krog": {"sign": -1, "lower": 0, "upper": 1},
                 "krg": {"sign": 1, "lower": 0, "upper": 1},
                 "pc": {"sign": 1, "allowzero": True},

--- a/pyscal/gaswater.py
+++ b/pyscal/gaswater.py
@@ -90,7 +90,7 @@ class GasWater(object):
 
         Performs tests if necessary data is ready in the object for
         printing Eclipse include files, and checks some numerical
-        properties (direction and monotonocity)
+        properties (direction and monotonicity)
 
         Returns:
             bool

--- a/pyscal/utils/string.py
+++ b/pyscal/utils/string.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from .monotonocity import modify_dframe_monotonocity
+from .monotonicity import modify_dframe_monotonicity
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +12,7 @@ def df2str(
     digits=7,
     roundlevel=9,
     header=False,
-    monotonocity=None,
+    monotonicity=None,
     monotone_column=None,
     monotone_direction=None,
 ):
@@ -21,7 +21,7 @@ def df2str(
     proper rounding.
 
     This is used to print the tables in the SWOF/SGOF include files,
-    explicit rounding is necessary to avoid monotonocity errors
+    explicit rounding is necessary to avoid monotonicity errors
     from truncation. Examples in test code.
 
     Capillary pressure must be strictly monotone if nonzero, and if a
@@ -38,16 +38,16 @@ def df2str(
         roundlevel (int): To how many digits should we round prior to print.
             Recommended to be > digits + 1, see test code.
         header (bool): If the dataframe column header should be included
-        monotonocity (dict): Settings for monotonocity in output. A dict
+        monotonicity (dict): Settings for monotonicity in output. A dict
             with column names as keys, with values being a dict with keys
             "sign" (-1 or +1 integer) for direction,  "upper" and "lower" for
-            lower and upper limits (non-strict monotonocity is allowed at
+            lower and upper limits (non-strict monotonicity is allowed at
             these upper and lower limits).
     """
     float_format = "%1." + str(digits) + "f"
 
-    if monotonocity is not None:
-        dframe = modify_dframe_monotonocity(dframe, monotonocity, digits)
+    if monotonicity is not None:
+        dframe = modify_dframe_monotonicity(dframe, monotonicity, digits)
 
     return dframe.round(roundlevel).to_csv(
         sep=" ", float_format=float_format, header=header, index=False

--- a/pyscal/wateroil.py
+++ b/pyscal/wateroil.py
@@ -833,7 +833,7 @@ class WaterOil(object):
         ) + co / (self.table["sonpc"] ** ao)
 
         # From 1-sor, the pc is not defined. Extrapolate constantly, and let
-        # the non-monotonocity be fixed in the output generators.
+        # the non-monotonicity be fixed in the output generators.
         self.table["pc"].fillna(method="ffill", inplace=True)
 
     def add_LET_pc_pd(self, Lp, Ep, Tp, Lt, Et, Tt, Pcmax, Pct):
@@ -1094,7 +1094,7 @@ class WaterOil(object):
         )
         string += df2str(
             self.table[["sw", "krw", "krow", "pc"]],
-            monotonocity={
+            monotonicity={
                 "krow": {"sign": -1, "lower": 0, "upper": 1},
                 "krw": {"sign": 1, "lower": 0, "upper": 1},
                 "pc": {"sign": -1, "allowzero": True},
@@ -1162,7 +1162,7 @@ class WaterOil(object):
         )
         string += df2str(
             self.table[["sw", "krw", "pc"]],
-            monotonocity={
+            monotonicity={
                 "krw": {"sign": 1, "lower": 0, "upper": 1},
                 "pc": {"sign": -1, "allowzero": True},
             }
@@ -1201,7 +1201,7 @@ class WaterOil(object):
         )
         string += df2str(
             self.table[["sw", "krw", "krow", "pc"]],
-            monotonocity={
+            monotonicity={
                 "krow": {"sign": -1, "lower": 0, "upper": 1},
                 "krw": {"sign": 1, "lower": 0, "upper": 1},
                 "pc": {"sign": -1, "allowzero": True},

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -429,7 +429,7 @@ def test_fast():
     # curves)
     assert "0.1000000 0.0100000 0.8100000 0.0000000" in gasoil.SGOF()
     assert "0.2000000 0.0400000 0.8099999 0.0000000" in gasoil.SGOF()
-    #   monotonocity correction:   ^^^^^^
+    #   monotonicity correction:   ^^^^^^
 
     # Now redo with fast option:
     gasoil = GasOil(h=0.1, fast=True)

--- a/tests/test_utils_monotonicity.py
+++ b/tests/test_utils_monotonicity.py
@@ -1,4 +1,4 @@
-"""Test module for monotonocity support functions in pyscal"""
+"""Test module for monotonicity support functions in pyscal"""
 
 import numpy as np
 import pandas as pd
@@ -6,53 +6,53 @@ import pandas as pd
 import pytest
 
 from pyscal.utils.string import df2str
-from pyscal.utils.monotonocity import (
+from pyscal.utils.monotonicity import (
     clip_accumulate,
     check_limits,
     rows_to_be_fixed,
     check_almost_monotone,
-    validate_monotonocity_arg,
+    validate_monotonicity_arg,
 )
 
 
 def test_df2str_monotone():
-    """Test the monotonocity enforcement in df2str()
+    """Test the monotonicity enforcement in df2str()
 
     This test function essentially tests the function
-    utils/monotonicity.py::modify_dframe_monotonocity
+    utils/monotonicity.py::modify_dframe_monotonicity
     """
 
     # A constant nonzero column, makes no sense as capillary pressure
     # but still we ensure it runs in eclipse:
     assert (
-        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": -1}})
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonicity={0: {"sign": -1}})
         == "1.00\n0.99\n0.98\n"
     )
     assert (
-        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": -1}})
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonicity={0: {"sign": -1}})
         == "1.00\n0.99\n0.98\n"
     )
     assert (
-        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": -1}})
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonicity={0: {"sign": -1}})
         == "1.00\n0.99\n0.98\n"
     )
     assert (
-        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": 1}})
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonicity={0: {"sign": 1}})
         == "1.00\n1.01\n1.02\n"
     )
     assert (
-        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonocity={0: {"sign": 1}})
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=2, monotonicity={0: {"sign": 1}})
         == "1.00\n1.01\n1.02\n"
     )
     assert (
-        df2str(pd.DataFrame(data=[1, 1, 1]), digits=7, monotonocity={0: {"sign": -1}})
+        df2str(pd.DataFrame(data=[1, 1, 1]), digits=7, monotonicity={0: {"sign": -1}})
         == "1.0000000\n0.9999999\n0.9999998\n"
     )
 
     # For strict monotonicity we will introduce negativity:
     dframe = pd.DataFrame(data=[0.00001, 0.0, 0.0, 0.0], columns=["pc"])
     assert (
-        df2str(dframe, monotonocity={"pc": {"sign": -1}})
+        df2str(dframe, monotonicity={"pc": {"sign": -1}})
         == "0.0000100\n0.0000000\n-0.0000001\n-0.0000002\n"
     )
 
@@ -61,13 +61,13 @@ def test_df2str_monotone():
         data=[0.0000027, 0.0000026, 0.0000024, 0.0000024, 0.0000017], columns=["pc"]
     )
     assert (
-        df2str(dframe, monotonocity={"pc": {"sign": -1}})
+        df2str(dframe, monotonicity={"pc": {"sign": -1}})
         == "0.0000027\n0.0000026\n0.0000024\n0.0000023\n0.0000017\n"
     )
 
 
 @pytest.mark.parametrize(
-    "series, monotonocity, expected",
+    "series, monotonicity, expected",
     [
         (
             [0.00, 0.0002, 0.01, 0.010001, 0.0100001, 0.01, 0.99, 1.0001, 1.00],
@@ -133,7 +133,7 @@ def test_df2str_monotone():
             {0: {"sign": -1}, 1: {"sign": 1}},
             ["1.00 1.00", "0.99 1.01", "0.98 1.02"],
         ),
-        # Example in docstring for modify_dframe_monotonocity()
+        # Example in docstring for modify_dframe_monotonicity()
         (
             [0.00, 0.0002, 0.01, 0.010001, 0.0100001, 0.01, 0.99, 0.999, 1.0001, 1.00],
             {0: {"sign": 1, "lower": 0, "upper": 1}},
@@ -152,13 +152,13 @@ def test_df2str_monotone():
         ),
     ],
 )
-def test_df2str_nonstrict_monotonocity(series, monotonocity, expected):
-    """Test that we can have non-strict monotonocity at upper and/or lower limits"""
+def test_df2str_nonstrict_monotonicity(series, monotonicity, expected):
+    """Test that we can have non-strict monotonicity at upper and/or lower limits"""
     assert (
         df2str(
             pd.DataFrame(data=series),
             digits=2,
-            monotonocity=monotonocity,
+            monotonicity=monotonicity,
         ).splitlines()
         == expected
     )
@@ -166,7 +166,7 @@ def test_df2str_nonstrict_monotonocity(series, monotonocity, expected):
 
 # Test similarly for digits=1:
 @pytest.mark.parametrize(
-    "series, monotonocity, expected",
+    "series, monotonicity, expected",
     [
         (
             [0.00, 0.0002, 0.01, 0.010001, 0.0100001, 0.01, 0.99, 1.0001, 1.00],
@@ -206,7 +206,7 @@ def test_df2str_nonstrict_monotonocity(series, monotonocity, expected):
             {0: {"sign": -1, "lower": 0, "upper": 1}},
             ["1.0", "0.1", "0.0", "0.0"],
         ),
-        # Example in docstring for modify_dframe_monotonocity()
+        # Example in docstring for modify_dframe_monotonicity()
         (
             [0.00, 0.0002, 0.01, 0.010001, 0.0100001, 0.01, 0.99, 0.999, 1.0001, 1.00],
             {0: {"sign": 1, "lower": 0, "upper": 1}},
@@ -225,20 +225,20 @@ def test_df2str_nonstrict_monotonocity(series, monotonocity, expected):
         ),
     ],
 )
-def test_df2str_nonstrict_monotonocity_digits1(series, monotonocity, expected):
-    """Test that we can have non-strict monotonocity at upper and/or lower limits"""
+def test_df2str_nonstrict_monotonicity_digits1(series, monotonicity, expected):
+    """Test that we can have non-strict monotonicity at upper and/or lower limits"""
     assert (
         df2str(
             pd.DataFrame(data=series),
             digits=1,
-            monotonocity=monotonocity,
+            monotonicity=monotonicity,
         ).splitlines()
         == expected
     )
 
 
 @pytest.mark.parametrize(
-    "series, monotonocity",
+    "series, monotonicity",
     [
         (
             [0, 1],
@@ -263,18 +263,18 @@ def test_df2str_nonstrict_monotonocity_digits1(series, monotonocity, expected):
         ([0], {0: {"sign": 1, "lower": 1}}),
     ],
 )
-def test_df2str_nonstrict_monotonocity_valueerror(series, monotonocity):
+def test_df2str_nonstrict_monotonicity_valueerror(series, monotonicity):
     """Check we get ValueError in the correct circumstances"""
     with pytest.raises(ValueError):
         df2str(
             pd.DataFrame(data=series),
             digits=2,
-            monotonocity=monotonocity,
+            monotonicity=monotonicity,
         )
 
 
 @pytest.mark.parametrize(
-    "series, monotonocity, expected_series",
+    "series, monotonicity, expected_series",
     [
         ([], {"sign": 1}, []),
         ([0], {"sign": 1}, [0]),
@@ -288,14 +288,14 @@ def test_df2str_nonstrict_monotonocity_valueerror(series, monotonocity):
         ([0, 2], {"sign": -1, "upper": 1, "lower": 0.1}, [0.1, 0.1]),
     ],
 )
-def test_clip_accumulate(series, monotonocity, expected_series):
+def test_clip_accumulate(series, monotonicity, expected_series):
     """Test that we are able to clip to upper and lower limits, and
-    use numpy's accumulate to ensure non-strict monotonocity"""
-    assert (clip_accumulate(series, monotonocity) == expected_series).all()
+    use numpy's accumulate to ensure non-strict monotonicity"""
+    assert (clip_accumulate(series, monotonicity) == expected_series).all()
 
 
 @pytest.mark.parametrize(
-    "series, monotonocity, colname, error_str",
+    "series, monotonicity, colname, error_str",
     [
         ([], {}, "", None),
         ([], {}, "foo", None),
@@ -305,19 +305,19 @@ def test_clip_accumulate(series, monotonocity, expected_series):
         ([2], {"lower": 3}, "foobar", "smaller than lower limit in column foobar"),
     ],
 )
-def test_check_limits(series, monotonocity, colname, error_str):
+def test_check_limits(series, monotonicity, colname, error_str):
     """Test that we can check upper and lower limits in series
     with proper error messages."""
     if error_str is not None:
         with pytest.raises(ValueError) as err:
-            check_limits(series, monotonocity, colname)
+            check_limits(series, monotonicity, colname)
         assert error_str in str(err)
     else:
-        check_limits(series, monotonocity, colname)
+        check_limits(series, monotonicity, colname)
 
 
 @pytest.mark.parametrize(
-    "series, monotonocity, digits, expected",
+    "series, monotonicity, digits, expected",
     [
         ([], {"sign": 1}, 0, []),
         ([], {"sign": 1}, 2, []),
@@ -335,10 +335,10 @@ def test_check_limits(series, monotonocity, colname, error_str):
         ([0.1, 0], {"sign": -1, "lower": 0}, 0, [False, False]),
     ],
 )
-def test_rows_to_be_fixed(series, monotonocity, digits, expected):
+def test_rows_to_be_fixed(series, monotonicity, digits, expected):
     """Check that we can make a boolean array of which elements must be fixed for
-    monotonocity"""
-    assert (rows_to_be_fixed(series, monotonocity, digits) == expected).all()
+    monotonicity"""
+    assert (rows_to_be_fixed(series, monotonicity, digits) == expected).all()
 
 
 @pytest.mark.parametrize(
@@ -365,14 +365,14 @@ def test_check_almost_monotone(series, digits, sign, expected_error):
 
 
 @pytest.mark.parametrize(
-    "monotonocity, dframe_colnames, error_str",
+    "monotonicity, dframe_colnames, error_str",
     [
         ({}, [], None),
-        ("sign", [], "monotonocity argument must be a dict"),
-        ({"sign": 1}, [], "monotonocity argument must be a dict of dicts"),
+        ("sign", [], "monotonicity argument must be a dict"),
+        ({"sign": 1}, [], "monotonicity argument must be a dict of dicts"),
         ({"foo": {"sign": 1}}, [], "Column foo does not exist in dataframe"),
         ({"foo": {"sign": 1}}, ["foo"], None),
-        ({"foo": {"sgn": 1}}, ["foo"], "Unknown keys in monotonocity dict"),
+        ({"foo": {"sgn": 1}}, ["foo"], "Unknown keys in monotonicity dict"),
         ({"foo": {"upper": 1}}, ["foo"], "Monotonocity sign not specified for foo"),
         ({"foo": {"sign": 1, "upper": 1}}, ["foo"], None),
         ({"foo": {"sign": 1, "lower": 1}}, ["foo"], None),
@@ -380,7 +380,7 @@ def test_check_almost_monotone(series, digits, sign, expected_error):
         (
             {"foo": {"sign": 1, "allowzero": "yes"}},
             ["foo"],
-            "allowzero in monotonocity argument must be True/False",
+            "allowzero in monotonicity argument must be True/False",
         ),
         (
             {"foo": {"sign": "positive"}},
@@ -391,11 +391,11 @@ def test_check_almost_monotone(series, digits, sign, expected_error):
         ({"foo": {"sign": -2}}, ["foo"], "Monotonocity sign must be -1 or +1"),
     ],
 )
-def test_validate_monotonocity_arg(monotonocity, dframe_colnames, error_str):
-    """Check error messages for monotonocity dictionaries"""
+def test_validate_monotonicity_arg(monotonicity, dframe_colnames, error_str):
+    """Check error messages for monotonicity dictionaries"""
     if error_str is not None:
         with pytest.raises(ValueError) as err:
-            validate_monotonocity_arg(monotonocity, dframe_colnames)
+            validate_monotonicity_arg(monotonicity, dframe_colnames)
         assert error_str in str(err)
     else:
-        validate_monotonocity_arg(monotonocity, dframe_colnames)
+        validate_monotonicity_arg(monotonicity, dframe_colnames)

--- a/tests/test_wateroil.py
+++ b/tests/test_wateroil.py
@@ -151,7 +151,7 @@ def test_fast():
     # curves)
     assert "0.1000000 0.0100000 0.8100000 0.0000000" in wateroil.SWOF()
     assert "0.2000000 0.0400000 0.8099999 0.0000000" in wateroil.SWOF()
-    #   monotonocity correction:   ^^^^^^
+    #   monotonicity correction:   ^^^^^^
 
     # Now redo with fast option:
     wateroil = WaterOil(h=0.1, fast=True)


### PR DESCRIPTION
This is an API break as both filenames, function names
and arguments have undergone the spelling error fix.

The part of the API that this breaks is almost internal to
pyscal. No external users of it is known.

Rationale:
* "monotonicity" has ~14 million search hits
* "monotonocity" has ~10 thousands search hits