### PR TITLE
Avoid sgcr being close to zero

### DIFF
--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -99,11 +99,30 @@ class GasOil(object):
         if not np.isclose(sorg, 0.0) and sorg < 1.0 / SWINTEGERS:
             # Too small but nonzero sorg gives too many numerical issues.
             logger.warning("sorg was close to zero, set to zero")
-            sorg = 0.0
-        self.sorg = sorg
-        self.sgro = sgro
+            self.sorg = 0.0
+        else:
+            self.sorg = sorg
 
-        self.sgcr = sgcr
+        if not np.isclose(sgcr, 0.0) and sgcr < 1.0 / SWINTEGERS:
+            # Too small but nonzero sgcr gives too many numerical issues.
+            logger.warning("sgcr was close to zero, set to zero")
+            self.sgcr = 0.0
+        else:
+            self.sgcr = sgcr
+
+        if not np.isclose(sgro, 0.0) and sgro < 1.0 / SWINTEGERS:
+            # Too small but nonzero sgro gives too many numerical issues.
+            logger.warning("sgro was close to zero, set to zero")
+            self.sgro = 0.0
+        else:
+            self.sgro = sgro
+        if not (np.isclose(self.sgro, 0) or np.isclose(self.sgro, self.sgcr)):
+            raise ValueError(
+                "sgro must be zero or equal to sgcr, for compatibility with "
+                "Eclipse three-point scaling. "
+                f"sgro: {sgro}, sgcr: {sgcr}."
+            )
+
         self.tag = tag
 
         if krgendanchor in ["sorg", ""]:
@@ -126,24 +145,17 @@ class GasOil(object):
                 "No saturation range left for gas curve between endpoints, check input"
             )
 
-        if not 1 - swl - sorg - sgro > 0:
+        if not 1 - self.swl - self.sorg - self.sgro > 0:
             raise ValueError(
                 "No saturation range left for oil curve between endpoints, check input"
             )
 
-        if not (np.isclose(sgro, 0) or np.isclose(sgro, sgcr)):
-            raise ValueError(
-                "sgro must be zero or equal to sgcr, for compatibility with "
-                "Eclipse three-point scaling. "
-                f"sgro: {sgro}, sgcr: {sgcr}."
-            )
-
         sg_list = (
             [0.0]
-            + [sgcr]
-            + list(np.arange(sgcr + self.h, 1 - sorg - swl, self.h))
-            + [1 - sorg - swl]
-            + [1 - swl]
+            + [self.sgcr]
+            + list(np.arange(self.sgcr + self.h, 1 - self.sorg - self.swl, self.h))
+            + [1 - self.sorg - self.swl]
+            + [1 - self.swl]
         )
         sg_list.sort()
         self.table = pd.DataFrame(sg_list, columns=["SG"])
@@ -161,7 +173,7 @@ class GasOil(object):
 
         sgcrindex = (self.table["SG"] - (self.sgcr)).abs().sort_values().index[0]
         self.table.loc[sgcrindex, "SG"] = self.sgcr
-        if sgcrindex == 0 and sgcr > 0.0:
+        if sgcrindex == 0 and self.sgcr > 0.0:
             # Need to conserve sg=0
             zero_row = pd.DataFrame({"SG": 0}, index=[0])
             self.table = pd.concat([zero_row, self.table], sort=False).reset_index(
@@ -185,13 +197,19 @@ class GasOil(object):
         if krgendanchor == "sorg":
             # Normalized sg (sgn) is 0 at sgcr, and 1 at 1-swl-sorg
             assert 1 - swl - sgcr - sorg > epsilon
-            self.table["SGN"] = (self.table["SG"] - sgcr) / (1 - swl - sgcr - sorg)
+            self.table["SGN"] = (self.table["SG"] - self.sgcr) / (
+                1 - self.swl - self.sgcr - self.sorg
+            )
         else:
             assert 1 - swl - sgcr > epsilon
-            self.table["SGN"] = (self.table["SG"] - sgcr) / (1 - swl - sgcr)
+            self.table["SGN"] = (self.table["SG"] - self.sgcr) / (
+                1 - self.swl - self.sgcr
+            )
 
         # Normalized oil saturation should be 0 at sg=1-swl-sorg, and 1 at sg=sgro
-        self.table["SON"] = (self.table["SL"] - sorg - swl) / (1 - sorg - swl - sgro)
+        self.table["SON"] = (self.table["SL"] - self.sorg - self.swl) / (
+            1 - self.sorg - self.swl - self.sgro
+        )
         self.sgcomment = (
             "-- swirr=%g, sgcr=%g, swl=%g, sorg=%g, sgro=%g, krgendanchor=%s\n"
             % (

--- a/pyscal/utils/testing.py
+++ b/pyscal/utils/testing.py
@@ -33,7 +33,8 @@ def sat_table_str_ok(sat_table_str: str) -> None:
 
     Number of floats pr. line must be constant
     All numerical lines must be parseable to a rectangular dataframe
-    with only floats.
+    with only floats. The first column must contain only unique values
+    for every SATNUM.
     """
     assert sat_table_str
 
@@ -87,6 +88,11 @@ def sat_table_str_ok(sat_table_str: str) -> None:
     # The first column holds saturations, for pyscal test-data that
     # is always between zero and 1
     assert 0 <= dframe[0].min() <= dframe[0].max() <= 1
+
+    # Saturations should be unique, but only within each SATNUM.
+    # Assert this by checking that the two consecutive numbers in the
+    # first column are never the same:
+    assert (~np.isclose(dframe[0].diff().dropna(), 0)).all()
 
     # Second column is never capillary pressure, so there we can enforce the same
     assert 0 <= dframe[1].min() <= dframe[1].max() <= 1

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -123,7 +123,9 @@ def test_gasoil_normalization(swl, sgcr, sorg, h, tag):
     # Check that son is 1 at sg=0
     assert float_df_checker(gasoil.table, "SG", 0, "SON", 1)
 
-    # Check that son is 0 at sorg with this krgendanchor
+    # Check that son is 0 at sorg with this krgendanchor.
+    # It is important to use the endpoints from the returned gasoil
+    # object, as they can be modified in case they are too close to zero.
     assert float_df_checker(gasoil.table, "SG", 1 - gasoil.sorg - gasoil.swl, "SON", 0)
 
     # Check that sgn is 0 at sgcr
@@ -174,6 +176,7 @@ def test_gasoil_krendmax(
     check_table(gasoil.table)
     check_linear_sections(gasoil)
     assert gasoil.selfcheck()
+    sat_table_str_ok(gasoil.SGOF())
     check_endpoints(gasoil, krgend, krgmax, kroend, kromax)
     assert 0 < gasoil.crosspoint() < 1
 
@@ -203,13 +206,14 @@ def check_endpoints(gasoil, krgend, krgmax, kroend, kromax):
     swtol = 1 / SWINTEGERS
 
     # Oil curve, from sg = 0 to sg = 1:
-    if gasoil.sgro < swtol:
-        assert float_df_checker(gasoil.table, "SG", 0, "KROG", kroend)
-        assert np.isclose(gasoil.table["KROG"].max(), kroend)
-    else:
+    if gasoil.sgro > 0:
+        # Gas-condensate: sgcr = sgro > 0
         assert float_df_checker(gasoil.table, "SG", 0, "KROG", kromax)
         assert float_df_checker(gasoil.table, "SON", 1.0, "KROG", kroend)
         assert np.isclose(gasoil.table["KROG"].max(), kromax)
+    else:
+        assert float_df_checker(gasoil.table, "SG", 0, "KROG", kroend)
+        assert np.isclose(gasoil.table["KROG"].max(), kroend)
 
     # son=0 @ 1 - sorg - swl or 1 - swl) should be zero:
     assert float_df_checker(gasoil.table, "SON", 0.0, "KROG", 0)


### PR DESCRIPTION
Having endpoints close to zero, and beyond the saturation step-size
gives a lot of numerical issues, and they are better avoided.

GasOil is now more similar to WaterOil, which was already robust to this.

Solves #291 