### PR TITLE
Fix doc deploy

### DIFF
--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -82,6 +82,7 @@ jobs:
             git config --local user.email "pyscal-github-action"
             git config --local user.name "pyscal-github-action"
             git fetch origin gh-pages
+            git stash  # Due to make_plots.py above maybe having modified png files
             git checkout --track origin/gh-pages
             git clean -f -f -d -x  # Double -f is intentional
             git rm -r *


### PR DESCRIPTION
The png files made by make_plots.py might get modified while running the CI workflow, and then we need to stash those changes before checking out `gh_pages`.  Freshly generated images will be what is being deployed nevertheless.

A better solution would be to take those png files out of git. The problem with that is that generating these plots are cumbersome on-prem as the xkcd font is not installed.