### PR TITLE
Fix Pandas 1.3.0 compatibility

### DIFF
--- a/pyscal/factory.py
+++ b/pyscal/factory.py
@@ -1205,7 +1205,7 @@ def infer_tabular_file_format(filename: Union[str, Path]) -> str:
     try:
         pd.read_excel(filename, engine="xlrd")
         return "xls"
-    except (ValueError, xlrd.biffh.XLRDError):
+    except (ValueError, TypeError, xlrd.biffh.XLRDError):
         # We get here for both CSV and XLSX files.
         pass
     try:


### PR DESCRIPTION
Pandas 1.3.0 upgrade resulted in an error in xlrd, when both Pandas and xlrd are stretched to infer file formats. Code is proven by tests, not by code-staring..