### PR TITLE
Ensure xkcd font is installed on doc deploy

### DIFF
--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Build documentation
         run: |
           sudo apt-get install -y fonts-humor-sans
+          python -c "import matplotlib.font_manager; matplotlib.font_manager._rebuild()"
           python docs/make_plots.py
           python setup.py build_sphinx
 

--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Build documentation
         run: |
+          sudo apt-get install -y fonts-humor-sans
           python docs/make_plots.py
           python setup.py build_sphinx
 

--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -60,10 +60,14 @@ jobs:
         run: |
           rstcheck -r docs
 
-      - name: Build documentation
+      - name: Install font (xkcd) for documentation
+        if: matrix.python-version == '3.6'
         run: |
           sudo apt-get install -y fonts-humor-sans
           python -c "import matplotlib.font_manager; matplotlib.font_manager._rebuild()"
+
+      - name: Build documentation
+        run: |
           python docs/make_plots.py
           python setup.py build_sphinx
 


### PR DESCRIPTION
The xkcd font seems to have vanished from the default image on github action runners. Ensure it is installed to get the plots for the documentation rendered nicely.

This fix is only for Python 3.6 which is the version used to deploy docs. The matplotlib.rebuild will fail in Python 3.8.