### PR TITLE
Make close-to-zero fixing robust

### DIFF
--- a/pyscal/utils/relperm.py
+++ b/pyscal/utils/relperm.py
@@ -7,8 +7,21 @@ import numpy as np
 import pandas as pd
 
 from ..constants import EPSILON as epsilon
+from ..constants import SWINTEGERS
 
 logger = logging.getLogger(__name__)
+
+
+def truncate_zeroness(
+    value: float, zeronesslimit: float = 1 / SWINTEGERS, name: str = "", log=True
+) -> float:
+    """Check a value for closeness to zero, and return as zero if below
+    a given limit, if not return the value"""
+    if value < zeronesslimit:
+        if log and name and not np.isclose(value, 0.0):
+            logger.warning("%s was close to zero, set to zero")
+        return 0.0
+    return value
 
 
 def crosspoint(dframe: pd.DataFrame, satcol: str, kr1col: str, kr2col: str) -> float:

--- a/pyscal/utils/relperm.py
+++ b/pyscal/utils/relperm.py
@@ -19,7 +19,7 @@ def truncate_zeroness(
     a given limit, if not return the value"""
     if value < zeronesslimit:
         if log and name and not np.isclose(value, 0.0):
-            logger.warning("%s was close to zero, set to zero")
+            logger.warning("%s was close to zero, set to zero", name)
         return 0.0
     return value
 

--- a/pyscal/wateroil.py
+++ b/pyscal/wateroil.py
@@ -12,7 +12,7 @@ import pyscal
 from pyscal.constants import EPSILON as epsilon
 from pyscal.constants import MAX_EXPONENT, SWINTEGERS
 from pyscal.utils.capillarypressure import simple_J
-from pyscal.utils.relperm import crosspoint, estimate_diffjumppoint
+from pyscal.utils.relperm import crosspoint, estimate_diffjumppoint, truncate_zeroness
 from pyscal.utils.string import comment_formatter, df2str
 
 logger = logging.getLogger(__name__)
@@ -98,14 +98,11 @@ class WaterOil(object):
 
         self.swirr = swirr
         self.swl = max(swl, swirr)  # Cannot allow swl < swirr. Warn?
-        if not np.isclose(sorw, 0) and sorw < 1 / SWINTEGERS:
-            # Give up handling sorw very close to zero
-            sorw = 0.0
+        self.sorw = truncate_zeroness(sorw, name="sorw")
         if self.swl < swcr < self.swl + 1 / SWINTEGERS + epsilon:
             # Give up handling swcr so close to swl
             swcr = self.swl
         self.swcr = max(self.swl, swcr)  # Cannot allow swcr < swl. Warn?
-        self.sorw = sorw
         self.tag = tag
         self.fast = fast
         sw_list = list(np.arange(self.swl, 1, self.h)) + [self.swcr] + [1 - sorw] + [1]

--- a/tests/test_utils_relperm.py
+++ b/tests/test_utils_relperm.py
@@ -4,9 +4,17 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pyscal.utils.relperm import crosspoint, estimate_diffjumppoint
+from pyscal.utils.relperm import crosspoint, estimate_diffjumppoint, truncate_zeroness
 
 # pyscal.utils.relperm.crosspoint() is also tested in test_wateroil and test_gasoil.
+
+
+@pytest.mark.parametrize(
+    "value, zeronesslimit, expected",
+    [(0, 0.1, 0), (0.01, 0.1, 0), (0.1, 0.1, 0.1), (1, 0.1, 1)],
+)
+def test_truncate_zeroness(value, zeronesslimit, expected):
+    assert truncate_zeroness(value, zeronesslimit=zeronesslimit) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The fixing of endpoints close to zero was not robust, as it
depended on what np.isclose accepted. 

Unsure what triggered this, either numpy updates or hypothesis got better at picking numbers to test.

Reviewers: Is `truncate_zeroness` a good function name?