### PR TITLE
Use the vetted sorg value to avoid numerical issues

### DIFF
--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -119,7 +119,7 @@ class GasOil(object):
 
         self.fast = fast
 
-        if np.isclose(sorg, 0.0) and self.krgendanchor == "sorg":
+        if np.isclose(self.sorg, 0.0) and self.krgendanchor == "sorg":
             self.krgendanchor = ""  # This is critical to avoid bugs due to numerics.
 
         if krgendanchor == "sorg" and not 1 - sorg - swl - sgcr > 0:


### PR DESCRIPTION
This fixes some CI failures that has happened un-consistently for Py36 only. Again, indicates that `np.isclose()` has changed behaviour. 