### PR TITLE
Removed unnecessary factory class Closes #101

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/pyscal/__init__.py
+++ b/pyscal/__init__.py
@@ -86,6 +86,7 @@ from .gaswater import GasWater  # noqa
 from .scalrecommendation import SCALrecommendation  # noqa
 from .pyscallist import PyscalList  # noqa
 from .factory import (
+    slicedict,
     create_water_oil,
     create_gas_oil,
     create_water_oil_gas,
@@ -100,4 +101,9 @@ from .factory import (
     create_wateroil_list,
     create_gasoil_list,
     create_gaswater_list,
+    sufficient_water_oil_params,
+    sufficient_gas_oil_params,
+    sufficient_gas_water_params,
+    filter_nan_from_dict,
+    infer_tabular_file_format,
 )  # noqa

--- a/pyscal/__init__.py
+++ b/pyscal/__init__.py
@@ -85,4 +85,19 @@ from .gasoil import GasOil  # noqa
 from .gaswater import GasWater  # noqa
 from .scalrecommendation import SCALrecommendation  # noqa
 from .pyscallist import PyscalList  # noqa
-from .factory import *  # noqa
+from .factory import (
+    create_water_oil,
+    create_gas_oil,
+    create_water_oil_gas,
+    create_gas_water,
+    create_scal_recommendation,
+    load_relperm_df,
+    alias_sgrw,
+    remap_validate_cases,
+    create_scal_recommendation_list,
+    create_pyscal_list,
+    create_wateroilgas_list,
+    create_wateroil_list,
+    create_gasoil_list,
+    create_gaswater_list,
+)  # noqa

--- a/pyscal/__init__.py
+++ b/pyscal/__init__.py
@@ -85,4 +85,4 @@ from .gasoil import GasOil  # noqa
 from .gaswater import GasWater  # noqa
 from .scalrecommendation import SCALrecommendation  # noqa
 from .pyscallist import PyscalList  # noqa
-from .factory import PyscalFactory  # noqa
+from .factory import *  # noqa

--- a/pyscal/factory.py
+++ b/pyscal/factory.py
@@ -90,941 +90,887 @@ GW_SIMPLE_J_PETRO = [
 WOG_INIT = ["swirr", "swl", "swcr", "sorw", "socr", "sorg", "sgcr", "h", "tag"]
 
 
-class PyscalFactory(object):
-    """Class for implementing the factory pattern for Pyscal objects
+def create_water_oil(
+    params: Optional[Dict[str, float]] = None, fast: bool = False
+) -> WaterOil:
+    """Create a WaterOil object from a dictionary of parameters.
 
-    The factory functions herein can take multiple parameter sets,
-    determine what kind of parametrization to be used, and set up
-    the full objects based on these parameters, instead of
-    explicitly having to call the API for each task.
+    Parameterization (Corey/LET) is inferred from presence
+    of certain parameters in the dictionary.
 
-    Example::
+    Don't rely on behaviour of you supply both Corey and LET at
+    the same time.
 
-      wo = WaterOil(sorw=0.05)
-      wo.add_corey_water(nw=3)
-      wo.add_corey_oil(now=2)
-      # is equivalent to:
-      wo = factory.create_water_oil(dict(sorw=0.05, nw=3, now=2))
+    Parameter names in the dictionary are case insensitive. You
+    can use Swirr, swirr, sWirR, swiRR etc.
 
-    Parameter names to factory functions are case *insensitive*, while
-    the add_*() parameters are not. This is because the add_*() parameters
-    are meant as a Python API, while the factory class is there to aid
-    users when input is written in a different context, like an Excel
-    spreadsheet.
+    NB: the add_LET_* methods have the names 'l', 'e' and 't'
+    in their signatures, which is not precise enough in this
+    context, so we require e.g. 'Lw' and 'Low' (which both will be
+    translated to 'l')
+
+    Recognized parameters:
+        swirr, swl, swcr, sorw, socr, sgrw, h, tag, nw, now, krwmax, krwend,
+        lw, ew, tw, low, eow, tow, lo, eo, to, kroend,
+        a, a_petro, b, b_petro, poro_ref, perm_ref, drho,
+        a, b, poro, perm, sigma_costau
+
+    Args:
+        params: Dictionary with parameters describing the WaterOil object.
+        fast: If fast-mode should be set for constructed object.
     """
+    if not params:
+        params = {}
+    if not isinstance(params, dict):
+        raise TypeError("Parameter to create_water_oil must be a dictionary")
 
-    @staticmethod
-    def create_water_oil(
-        params: Optional[Dict[str, float]] = None, fast: bool = False
-    ) -> WaterOil:
-        """Create a WaterOil object from a dictionary of parameters.
+    check_deprecated(params)
 
-        Parameterization (Corey/LET) is inferred from presence
-        of certain parameters in the dictionary.
+    sufficient_water_oil_params(params, failhard=True)
 
-        Don't rely on behaviour of you supply both Corey and LET at
-        the same time.
+    # For case insensitiveness, all keys are converted to lower case:
+    params = {key.lower(): value for (key, value) in params.items()}
 
-        Parameter names in the dictionary are case insensitive. You
-        can use Swirr, swirr, sWirR, swiRR etc.
+    # Allowing sending in NaN values, delete those keys.
+    params = filter_nan_from_dict(params)
 
-        NB: the add_LET_* methods have the names 'l', 'e' and 't'
-        in their signatures, which is not precise enough in this
-        context, so we require e.g. 'Lw' and 'Low' (which both will be
-        translated to 'l')
+    usedparams: Set[str] = set()
 
-        Recognized parameters:
-          swirr, swl, swcr, sorw, socr, sgrw, h, tag, nw, now, krwmax, krwend,
-          lw, ew, tw, low, eow, tow, lo, eo, to, kroend,
-          a, a_petro, b, b_petro, poro_ref, perm_ref, drho,
-          a, b, poro, perm, sigma_costau
-
-        Args:
-            params: Dictionary with parameters describing the WaterOil object.
-            fast: If fast-mode should be set for constructed object.
-        """
-        if not params:
-            params = {}
-        if not isinstance(params, dict):
-            raise TypeError("Parameter to create_water_oil must be a dictionary")
-
-        check_deprecated(params)
-
-        sufficient_water_oil_params(params, failhard=True)
-
-        # For case insensitiveness, all keys are converted to lower case:
-        params = {key.lower(): value for (key, value) in params.items()}
-
-        # Allowing sending in NaN values, delete those keys.
-        params = filter_nan_from_dict(params)
-
-        usedparams: Set[str] = set()
-
-        # Check if we should initialize swl from a swlheight parameter:
-        if set(WO_SWL_FROM_HEIGHT).issubset(params):
-            if "swl" in params:
-                raise ValueError(
-                    "Do not provide both swl and swlheight at the same time"
-                )
-            if params["swlheight"] <= 0:
-                raise ValueError("swlheight must be larger than zero")
-            params_swl_from_height = slicedict(params, WO_SWL_FROM_HEIGHT)
-            params["swl"] = capillarypressure.swl_from_height_simpleJ(
-                **params_swl_from_height
+    # Check if we should initialize swl from a swlheight parameter:
+    if set(WO_SWL_FROM_HEIGHT).issubset(params):
+        if "swl" in params:
+            raise ValueError("Do not provide both swl and swlheight at the same time")
+        if params["swlheight"] <= 0:
+            raise ValueError("swlheight must be larger than zero")
+        params_swl_from_height = slicedict(params, WO_SWL_FROM_HEIGHT)
+        params["swl"] = capillarypressure.swl_from_height_simpleJ(
+            **params_swl_from_height
+        )
+        logger.debug("Computed swl from swlwheight to %s", str(params["swl"]))
+        if "swcr" in params and params["swcr"] < params["swl"]:
+            raise ValueError(
+                f'Provided swcr={params["swcr"]} is lower than '
+                f'computed swl={params["swl"]}'
             )
-            logger.debug("Computed swl from swlwheight to %s", str(params["swl"]))
-            if "swcr" in params and params["swcr"] < params["swl"]:
-                raise ValueError(
-                    f'Provided swcr={params["swcr"]} is lower than '
-                    f'computed swl={params["swl"]}'
-                )
-        elif set(WO_SWLHEIGHT).issubset(params):
+    elif set(WO_SWLHEIGHT).issubset(params):
+        raise ValueError(
+            (
+                "Can't initialize from SWLHEIGHT without sufficient "
+                f"simple-J parameters, needs all of: {WO_SWL_FROM_HEIGHT}"
+            )
+        )
+
+    # Should we have a swcr relative to swl?
+    if set(WO_SWCR_ADD).issubset(params):
+        if "swl" not in params:
             raise ValueError(
                 (
-                    "Can't initialize from SWLHEIGHT without sufficient "
-                    f"simple-J parameters, needs all of: {WO_SWL_FROM_HEIGHT}"
+                    "If swcr should be relative to swl, "
+                    "both swcr_add and swl must be provided"
                 )
             )
+        if "swcr" in params:
+            raise ValueError("Do not provide both swcr and swcr_add at the same time")
+        params["swcr"] = params["swl"] + params[WO_SWCR_ADD[0]]
 
-        # Should we have a swcr relative to swl?
-        if set(WO_SWCR_ADD).issubset(params):
-            if "swl" not in params:
-                raise ValueError(
-                    (
-                        "If swcr should be relative to swl, "
-                        "both swcr_add and swl must be provided"
-                    )
-                )
-            if "swcr" in params:
-                raise ValueError(
-                    "Do not provide both swcr and swcr_add at the same time"
-                )
-            params["swcr"] = params["swl"] + params[WO_SWCR_ADD[0]]
+    # No requirements to the base objects, defaults are ok.
+    wateroil = WaterOil(**alias_sgrw(slicedict(params, WO_INIT)), fast=fast)
+    usedparams = usedparams.union(set(slicedict(params, WO_INIT).keys()))
+    logger.debug(
+        "Initialized WaterOil object from parameters %s", str(list(usedparams))
+    )
 
-        # No requirements to the base objects, defaults are ok.
-        wateroil = WaterOil(
-            **PyscalFactory.alias_sgrw(slicedict(params, WO_INIT)), fast=fast
-        )
-        usedparams = usedparams.union(set(slicedict(params, WO_INIT).keys()))
+    # Water curve
+    params_corey_water = slicedict(params, WO_COREY_WATER + WO_WATER_ENDPOINTS)
+    params_let_water = slicedict(params, WO_LET_WATER + WO_WATER_ENDPOINTS)
+    if set(WO_COREY_WATER).issubset(set(params_corey_water)):
+        wateroil.add_corey_water(**params_corey_water)
         logger.debug(
-            "Initialized WaterOil object from parameters %s", str(list(usedparams))
+            "Added Corey water to WaterOil object from parameters %s",
+            str(params_corey_water.keys()),
         )
-
-        # Water curve
-        params_corey_water = slicedict(params, WO_COREY_WATER + WO_WATER_ENDPOINTS)
-        params_let_water = slicedict(params, WO_LET_WATER + WO_WATER_ENDPOINTS)
-        if set(WO_COREY_WATER).issubset(set(params_corey_water)):
-            wateroil.add_corey_water(**params_corey_water)
-            logger.debug(
-                "Added Corey water to WaterOil object from parameters %s",
-                str(params_corey_water.keys()),
-            )
-        elif set(WO_LET_WATER).issubset(set(params_let_water)):
-            params_let_water["l"] = params_let_water.pop("lw")
-            params_let_water["e"] = params_let_water.pop("ew")
-            params_let_water["t"] = params_let_water.pop("tw")
-            wateroil.add_LET_water(**params_let_water)
-            logger.debug(
-                "Added LET water to WaterOil object from parameters %s",
-                str(params_let_water.keys()),
-            )
-
-        # Oil curve:
-        params_corey_oil = slicedict(params, WO_COREY_OIL + WO_OIL_ENDPOINTS)
-        params_let_oil = slicedict(
-            params, WO_LET_OIL + WO_LET_OIL_ALT + WO_OIL_ENDPOINTS
-        )
-        if set(WO_COREY_OIL).issubset(set(params_corey_oil)):
-            wateroil.add_corey_oil(**params_corey_oil)
-            logger.debug(
-                "Added Corey water to WaterOil object from parameters %s",
-                str(params_corey_oil.keys()),
-            )
-        elif set(WO_LET_OIL).issubset(set(params_let_oil)):
-            params_let_oil["l"] = params_let_oil.pop("low")
-            params_let_oil["e"] = params_let_oil.pop("eow")
-            params_let_oil["t"] = params_let_oil.pop("tow")
-            wateroil.add_LET_oil(**params_let_oil)
-            logger.debug(
-                "Added LET water to WaterOil object from parameters %s",
-                str(params_let_oil.keys()),
-            )
-        elif set(WO_LET_OIL_ALT).issubset(set(params_let_oil)):
-            params_let_oil["l"] = params_let_oil.pop("lo")
-            params_let_oil["e"] = params_let_oil.pop("eo")
-            params_let_oil["t"] = params_let_oil.pop("to")
-            wateroil.add_LET_oil(**params_let_oil)
-            logger.debug(
-                "Added LET water to WaterOil object from parameters %s",
-                str(params_let_oil.keys()),
-            )
-
-        # Capillary pressure:
-        params_simple_j = slicedict(params, WO_SIMPLE_J + ["g"])
-        params_norm_j = slicedict(params, WO_NORM_J)
-        params_simple_j_petro = slicedict(params, WO_SIMPLE_J_PETRO + ["g"])
-        if set(WO_SIMPLE_J).issubset(set(params_simple_j)):
-            wateroil.add_simple_J(**params_simple_j)
-        elif set(WO_SIMPLE_J_PETRO).issubset(set(params_simple_j_petro)):
-            params_simple_j_petro["a"] = params_simple_j_petro.pop("a_petro")
-            params_simple_j_petro["b"] = params_simple_j_petro.pop("b_petro")
-            wateroil.add_simple_J_petro(**params_simple_j_petro)
-        elif set(WO_NORM_J).issubset(set(params_norm_j)):
-            wateroil.add_normalized_J(**params_norm_j)
-        else:
-            logger.info(
-                (
-                    "Missing or ambiguous parameters for capillary pressure in "
-                    "WaterOil object. Using zero."
-                )
-            )
-        if not wateroil.selfcheck():
-            raise ValueError(
-                ("Incomplete WaterOil object, some parameters missing to factory")
-            )
-        return wateroil
-
-    @staticmethod
-    def create_gas_oil(
-        params: Optional[Dict[str, float]] = None, fast: bool = False
-    ) -> GasOil:
-        """Create a GasOil object from a dictionary of parameters.
-
-        Parameterization (Corey/LET) is inferred from presence
-        of certain parameters in the dictionary.
-
-        Don't rely on behaviour of you supply both Corey and LET at
-        the same time.
-
-        NB: the add_LET_* methods have the names 'l', 'e' and 't'
-        in their signatures, which is not precise enough in this
-        context, so we require e.g. 'Lg' and 'Log' (which both will be
-        translated to 'l').
-
-        Recognized parameters:
-          swirr, sgcr, sorg, swl, krgendanchor, h, tag,
-          ng, krgend, krgmax, nog, kroend, kromax
-          lg, eg, tg, log, eog, tog
-
-        Args:
-            params: Dictionary with parameters describing the GasOil object.
-            fast: If fast-mode should be set for constructed object.
-        """
-        if not params:
-            params = {}
-        if not isinstance(params, dict):
-            raise TypeError("Parameter to create_gas_oil must be a dictionary")
-
-        check_deprecated(params)
-
-        sufficient_gas_oil_params(params, failhard=True)
-
-        # For case insensitiveness, all keys are converted to lower case:
-        params = {key.lower(): value for (key, value) in params.items()}
-
-        # Allowing sending in NaN values, delete those keys.
-        params = filter_nan_from_dict(params)
-
-        usedparams: Set[str] = set()
-        # No requirements to the base objects, defaults are ok.
-        gasoil = GasOil(**slicedict(params, GO_INIT), fast=fast)
-        usedparams = usedparams.union(set(slicedict(params, GO_INIT).keys()))
+    elif set(WO_LET_WATER).issubset(set(params_let_water)):
+        params_let_water["l"] = params_let_water.pop("lw")
+        params_let_water["e"] = params_let_water.pop("ew")
+        params_let_water["t"] = params_let_water.pop("tw")
+        wateroil.add_LET_water(**params_let_water)
         logger.debug(
-            "Initialized GasOil object from parameters %s", str(list(usedparams))
+            "Added LET water to WaterOil object from parameters %s",
+            str(params_let_water.keys()),
         )
 
-        # Gas curve
-        params_corey_gas = slicedict(params, GO_COREY_GAS + GO_GAS_ENDPOINTS)
-        params_let_gas = slicedict(params, GO_LET_GAS + GO_GAS_ENDPOINTS)
-        if set(GO_COREY_GAS).issubset(set(params_corey_gas)):
-            gasoil.add_corey_gas(**params_corey_gas)
-            logger.debug(
-                "Added Corey gas to GasOil object from parameters %s",
-                str(params_corey_gas.keys()),
-            )
-        elif set(GO_LET_GAS).issubset(set(params_let_gas)):
-            params_let_gas["l"] = params_let_gas.pop("lg")
-            params_let_gas["e"] = params_let_gas.pop("eg")
-            params_let_gas["t"] = params_let_gas.pop("tg")
-            gasoil.add_LET_gas(**params_let_gas)
-            logger.debug(
-                "Added LET gas to GasOil object from parameters %s",
-                str(params_let_gas.keys()),
-            )
-        else:
-            logger.warning(
-                "Missing or ambiguous parameters for gas curve in GasOil object"
-            )
+    # Oil curve:
+    params_corey_oil = slicedict(params, WO_COREY_OIL + WO_OIL_ENDPOINTS)
+    params_let_oil = slicedict(params, WO_LET_OIL + WO_LET_OIL_ALT + WO_OIL_ENDPOINTS)
+    if set(WO_COREY_OIL).issubset(set(params_corey_oil)):
+        wateroil.add_corey_oil(**params_corey_oil)
+        logger.debug(
+            "Added Corey water to WaterOil object from parameters %s",
+            str(params_corey_oil.keys()),
+        )
+    elif set(WO_LET_OIL).issubset(set(params_let_oil)):
+        params_let_oil["l"] = params_let_oil.pop("low")
+        params_let_oil["e"] = params_let_oil.pop("eow")
+        params_let_oil["t"] = params_let_oil.pop("tow")
+        wateroil.add_LET_oil(**params_let_oil)
+        logger.debug(
+            "Added LET water to WaterOil object from parameters %s",
+            str(params_let_oil.keys()),
+        )
+    elif set(WO_LET_OIL_ALT).issubset(set(params_let_oil)):
+        params_let_oil["l"] = params_let_oil.pop("lo")
+        params_let_oil["e"] = params_let_oil.pop("eo")
+        params_let_oil["t"] = params_let_oil.pop("to")
+        wateroil.add_LET_oil(**params_let_oil)
+        logger.debug(
+            "Added LET water to WaterOil object from parameters %s",
+            str(params_let_oil.keys()),
+        )
 
-        # Oil curve:
-        params_corey_oil = slicedict(params, GO_COREY_OIL + GO_OIL_ENDPOINTS)
-        params_let_oil = slicedict(params, GO_LET_OIL + GO_OIL_ENDPOINTS)
-        if set(GO_COREY_OIL).issubset(set(params_corey_oil)):
-            gasoil.add_corey_oil(**params_corey_oil)
-            logger.debug(
-                "Added Corey gas to GasOil object from parameters %s",
-                str(params_corey_oil.keys()),
+    # Capillary pressure:
+    params_simple_j = slicedict(params, WO_SIMPLE_J + ["g"])
+    params_norm_j = slicedict(params, WO_NORM_J)
+    params_simple_j_petro = slicedict(params, WO_SIMPLE_J_PETRO + ["g"])
+    if set(WO_SIMPLE_J).issubset(set(params_simple_j)):
+        wateroil.add_simple_J(**params_simple_j)
+    elif set(WO_SIMPLE_J_PETRO).issubset(set(params_simple_j_petro)):
+        params_simple_j_petro["a"] = params_simple_j_petro.pop("a_petro")
+        params_simple_j_petro["b"] = params_simple_j_petro.pop("b_petro")
+        wateroil.add_simple_J_petro(**params_simple_j_petro)
+    elif set(WO_NORM_J).issubset(set(params_norm_j)):
+        wateroil.add_normalized_J(**params_norm_j)
+    else:
+        logger.info(
+            (
+                "Missing or ambiguous parameters for capillary pressure in "
+                "WaterOil object. Using zero."
             )
-        elif set(GO_LET_OIL).issubset(set(params_let_oil)):
-            params_let_oil["l"] = params_let_oil.pop("log")
-            params_let_oil["e"] = params_let_oil.pop("eog")
-            params_let_oil["t"] = params_let_oil.pop("tog")
-            gasoil.add_LET_oil(**params_let_oil)
-            logger.debug(
-                "Added LET gas to GasOil object from parameters %s",
-                str(params_let_oil.keys()),
-            )
-        else:
-            logger.warning(
-                "Missing or ambiguous parameters for oil curve in GasOil object"
-            )
-        if not gasoil.selfcheck():
+        )
+    if not wateroil.selfcheck():
+        raise ValueError(
+            ("Incomplete WaterOil object, some parameters missing to factory")
+        )
+    return wateroil
+
+
+def create_gas_oil(
+    params: Optional[Dict[str, float]] = None, fast: bool = False
+) -> GasOil:
+    """Create a GasOil object from a dictionary of parameters.
+
+    Parameterization (Corey/LET) is inferred from presence
+    of certain parameters in the dictionary.
+
+    Don't rely on behaviour of you supply both Corey and LET at
+    the same time.
+
+    NB: the add_LET_* methods have the names 'l', 'e' and 't'
+    in their signatures, which is not precise enough in this
+    context, so we require e.g. 'Lg' and 'Log' (which both will be
+    translated to 'l').
+
+    Recognized parameters:
+        swirr, sgcr, sorg, swl, krgendanchor, h, tag,
+        ng, krgend, krgmax, nog, kroend, kromax
+        lg, eg, tg, log, eog, tog
+
+    Args:
+        params: Dictionary with parameters describing the GasOil object.
+        fast: If fast-mode should be set for constructed object.
+    """
+    if not params:
+        params = {}
+    if not isinstance(params, dict):
+        raise TypeError("Parameter to create_gas_oil must be a dictionary")
+
+    check_deprecated(params)
+
+    sufficient_gas_oil_params(params, failhard=True)
+
+    # For case insensitiveness, all keys are converted to lower case:
+    params = {key.lower(): value for (key, value) in params.items()}
+
+    # Allowing sending in NaN values, delete those keys.
+    params = filter_nan_from_dict(params)
+
+    usedparams: Set[str] = set()
+    # No requirements to the base objects, defaults are ok.
+    gasoil = GasOil(**slicedict(params, GO_INIT), fast=fast)
+    usedparams = usedparams.union(set(slicedict(params, GO_INIT).keys()))
+    logger.debug("Initialized GasOil object from parameters %s", str(list(usedparams)))
+
+    # Gas curve
+    params_corey_gas = slicedict(params, GO_COREY_GAS + GO_GAS_ENDPOINTS)
+    params_let_gas = slicedict(params, GO_LET_GAS + GO_GAS_ENDPOINTS)
+    if set(GO_COREY_GAS).issubset(set(params_corey_gas)):
+        gasoil.add_corey_gas(**params_corey_gas)
+        logger.debug(
+            "Added Corey gas to GasOil object from parameters %s",
+            str(params_corey_gas.keys()),
+        )
+    elif set(GO_LET_GAS).issubset(set(params_let_gas)):
+        params_let_gas["l"] = params_let_gas.pop("lg")
+        params_let_gas["e"] = params_let_gas.pop("eg")
+        params_let_gas["t"] = params_let_gas.pop("tg")
+        gasoil.add_LET_gas(**params_let_gas)
+        logger.debug(
+            "Added LET gas to GasOil object from parameters %s",
+            str(params_let_gas.keys()),
+        )
+    else:
+        logger.warning("Missing or ambiguous parameters for gas curve in GasOil object")
+
+    # Oil curve:
+    params_corey_oil = slicedict(params, GO_COREY_OIL + GO_OIL_ENDPOINTS)
+    params_let_oil = slicedict(params, GO_LET_OIL + GO_OIL_ENDPOINTS)
+    if set(GO_COREY_OIL).issubset(set(params_corey_oil)):
+        gasoil.add_corey_oil(**params_corey_oil)
+        logger.debug(
+            "Added Corey gas to GasOil object from parameters %s",
+            str(params_corey_oil.keys()),
+        )
+    elif set(GO_LET_OIL).issubset(set(params_let_oil)):
+        params_let_oil["l"] = params_let_oil.pop("log")
+        params_let_oil["e"] = params_let_oil.pop("eog")
+        params_let_oil["t"] = params_let_oil.pop("tog")
+        gasoil.add_LET_oil(**params_let_oil)
+        logger.debug(
+            "Added LET gas to GasOil object from parameters %s",
+            str(params_let_oil.keys()),
+        )
+    else:
+        logger.warning("Missing or ambiguous parameters for oil curve in GasOil object")
+    if not gasoil.selfcheck():
+        raise ValueError(
+            ("Incomplete GasOil object, some parameters missing to factory")
+        )
+
+    return gasoil
+
+
+def create_water_oil_gas(
+    params: Optional[Dict[str, float]] = None, fast: bool = False
+) -> WaterOilGas:
+    """Create a WaterOilGas object from a dictionary of parameters
+
+    Parameterization (Corey/LET) is inferred from presence
+    of certain parameters in the dictionary.
+
+    Check create_water_oil() and create_gas_oil() for lists
+    of supported parameters (case insensitive)
+
+    Params:
+        params: Dictionary with parameters describing the WaterOilGas object.
+        fast: If fast-mode should be set for constructed object.
+    """
+    if not params:
+        params = {}
+    if not isinstance(params, dict):
+        raise TypeError("Parameter to create_water_oil_gas must be a dictionary")
+
+    check_deprecated(params)
+
+    # For case insensitiveness, all keys are converted to lower case:
+    params = {key.lower(): value for (key, value) in params.items()}
+
+    wateroil: Optional[WaterOil]
+    if sufficient_water_oil_params(params, failhard=False):
+        wateroil = create_water_oil(params, fast=fast)
+    else:
+        logger.info("No wateroil parameters. Assuming only gas-oil in wateroilgas")
+        wateroil = None
+
+    # If the swl in WaterOil was initialized with swlheight,
+    # ensure that result is passed on to the GasOil object:
+    if "swl" not in params and "swlheight" in params and wateroil is not None:
+        params["swl"] = wateroil.swl
+
+    gasoil: Optional[GasOil]
+    if sufficient_gas_oil_params(params, failhard=False):
+        gasoil = create_gas_oil(params, fast=fast)
+    else:
+        logger.info("No gasoil parameters, assuming two-phase oilwatergas")
+        gasoil = None
+
+    wog_init_params = slicedict(params, WOG_INIT)
+    wateroilgas = WaterOilGas(**wog_init_params, fast=fast)
+    # The wateroilgas __init__ has already created WaterOil and GasOil objects
+    # but we overwrite the references with newly created ones, this factory function
+    # must then guarantee that they are compatible.
+    wateroilgas.wateroil = wateroil  # This might be None
+    wateroilgas.gasoil = gasoil  # This might be None
+    if not wateroilgas.selfcheck():
+        raise ValueError(f"Inconsistent WaterOilGas object. Bug? Input was {params}")
+    return wateroilgas
+
+
+def create_gas_water(
+    params: Optional[Dict[str, float]] = None, fast: bool = False
+) -> GasWater:
+    """Create a GasWater object.
+
+    Parameterization (Corey/LET) is inferred from presence
+    of certain parameters in the dictionary.
+
+    Args:
+        params: Dictionary with parameters for GasWater.
+        fast: If fast-mode should be set for constructed object.
+    """
+    if not params:
+        params = {}
+    if not isinstance(params, dict):
+        raise TypeError("Parameter to create_gas_water must be a dictionary")
+
+    # For case insensitiveness, all keys are converted to lower case:
+    params = {key.lower(): value for (key, value) in params.items()}
+
+    sufficient_gas_water_params(params, failhard=True)
+
+    gw_init_params = slicedict(params, GW_INIT)
+    gaswater = GasWater(**gw_init_params, fast=fast)
+
+    # We are using the create_water_oil_gas factory function
+    # to avoid replicating code. It works because GasWater and
+    # WaterOilGas internally are very similar.
+    wog_params = params.copy()
+    if "sgrw" in params:
+        wog_params["sorw"] = params["sgrw"]
+    # Set some dummy parameters for oil:
+    wog_params["nog"] = 1
+    wog_params["now"] = 1
+    wog = create_water_oil_gas(wog_params, fast=fast)
+    assert wog.wateroil is not None
+    assert wog.gasoil is not None
+    gaswater.wateroil = wog.wateroil
+    gaswater.gasoil = wog.gasoil
+    return gaswater
+
+
+def create_scal_recommendation(
+    params: Dict[str, Dict[str, float]],
+    tag: str = "",
+    h: Optional[float] = None,
+    fast: bool = False,
+) -> SCALrecommendation:
+    """
+    Set up a SCAL recommendation curve set from input as a
+    dictionary of dictionary.
+
+    The keys in in the dictionary *must* be "low", "base" and "high".
+
+    The value for "low" must be a new dictionary with saturation
+    endpoints and LET/Corey parameters, as you would feed it to
+    the create_water_oil_gas() factory function, and then similarly
+    for base and high.
+
+    For oil-water only, you may omit the parameters for gas-oil.
+    A WaterOilGas object for each case is created, but only the
+    WaterOil part of it will be used.
+
+    For gas-water, a GasWater object is created for each pess, base
+    and high.
+
+    Args:
+        params: keys low, base and high.
+            The value for "low" must be a new dictionary with saturation
+            endpoints and LET/Corey parameters, as you would feed it to
+            the create_water_oil_gas() factory function, and then similarly
+            for base and high.
+        tag: String to be used as the tag, will end up in comments.
+        h: Saturation step length
+        fast: If fast-mode should be set for constructed object.
+    """
+    if not isinstance(params, dict):
+        raise ValueError("Input must be a dictionary (of dictionaries)")
+
+    # For case insensitiveness, all keys are converted to lower case:
+    params = {key.lower(): value for (key, value) in params.items()}
+
+    if "low" not in params:
+        raise ValueError('"low" case not supplied')
+    if "base" not in params:
+        raise ValueError('"base" case not supplied')
+    if "high" not in params:
+        raise ValueError('"high" case not supplied')
+    if not (
+        isinstance(params["low"], dict)
+        and isinstance(params["base"], dict)
+        and isinstance(params["high"], dict)
+    ):
+        raise ValueError("All values in parameter dict must be dictionaries")
+
+    check_deprecated(params["low"])
+    check_deprecated(params["base"])
+    check_deprecated(params["high"])
+
+    errored = False
+    if h is not None:
+        params["low"]["h"] = h
+        params["base"]["h"] = h
+        params["high"]["h"] = h
+
+    # Check parameter availability, in order to determine phase configuration
+    gaswater = all(sufficient_gas_water_params(params[case]) for case in params.keys())
+    gasoil = all(sufficient_gas_oil_params(params[case]) for case in params.keys())
+    wateroil = all(sufficient_water_oil_params(params[case]) for case in params.keys())
+
+    wog_low: Union[WaterOilGas, GasWater]
+    wog_base: Union[WaterOilGas, GasWater]
+    wog_high: Union[WaterOilGas, GasWater]
+
+    if wateroil or gasoil:
+        try:
+            wog_low = create_water_oil_gas(params["low"], fast=fast)
+        except ValueError as err:
+            raise ValueError(f"Problem with low/pess case: {err}") from err
+        try:
+            wog_base = create_water_oil_gas(params["base"], fast=fast)
+        except ValueError as err:
+            raise ValueError(f"Problem with base case: {err}") from err
+        try:
+            wog_high = create_water_oil_gas(params["high"], fast=fast)
+        except ValueError as err:
+            raise ValueError(f"Problem with high/opt case: {err}") from err
+    elif gaswater:
+        # Note that gaswater will be True in three-phase configs.
+        try:
+            wog_low = create_gas_water(params["low"], fast=fast)
+        except ValueError as err:
+            raise ValueError(f"Problem with low/pess case: {err}") from err
+        try:
+            wog_base = create_gas_water(params["base"], fast=fast)
+        except ValueError as err:
+            raise ValueError(f"Problem with base case: {err}") from err
+        try:
+            wog_high = create_gas_water(params["high"], fast=fast)
+        except ValueError as err:
+            raise ValueError(f"Problem with high/opt case: {err}") from err
+
+    errored = all(not wog.selfcheck() for wog in [wog_low, wog_base, wog_high])
+
+    if errored:
+        raise ValueError("Incomplete SCAL recommendation")
+
+    scal = SCALrecommendation(wog_low, wog_base, wog_high, tag)
+    return scal
+
+
+def load_relperm_df(
+    inputfile: Union[str, pd.DataFrame], sheet_name: Optional[str] = None
+) -> pd.DataFrame:
+    """Read CSV or XLSX from file and return scal/relperm data
+    a dataframe.
+
+    Checks validity in SATNUM and CASE columns.
+    Ensures case-insensitiveness SATNUM, CASE, TAG and COMMENT
+
+    Merges COMMENT into TAG column, as only TAG is picked up downstream.
+    Adds a prefix "SATNUM <number>" to all tags.
+
+    All strings in CASE column are converted to lowercase. Applies
+    aliasing in the CASE column so that "pessimistic" and "pess" map to
+    "low", and "optimistic" and "opt" map to "high".
+
+    Args:
+        inputfile: Filename for XLSX or CSV file, or a
+            pandas DataFrame.
+        sheet_name: Sheet-name, only used when loading xlsx files.
+
+    Returns:
+        To be handed over to pyscal list factory methods.
+        Empty dataframe in case of errors (messages will be logged).
+    """
+    if isinstance(inputfile, (str, Path)) and Path(inputfile).is_file():
+        tabular_file_format = infer_tabular_file_format(inputfile)
+        if not tabular_file_format:
             raise ValueError(
-                ("Incomplete GasOil object, some parameters missing to factory")
+                f"Impossible to infer file format for {inputfile}, not CSV/XLS/XLSX"
             )
 
-        return gasoil
-
-    @staticmethod
-    def create_water_oil_gas(
-        params: Optional[Dict[str, float]] = None, fast: bool = False
-    ) -> WaterOilGas:
-        """Create a WaterOilGas object from a dictionary of parameters
-
-        Parameterization (Corey/LET) is inferred from presence
-        of certain parameters in the dictionary.
-
-        Check create_water_oil() and create_gas_oil() for lists
-        of supported parameters (case insensitive)
-
-        Params:
-            params: Dictionary with parameters describing the WaterOilGas object.
-            fast: If fast-mode should be set for constructed object.
-        """
-        if not params:
-            params = {}
-        if not isinstance(params, dict):
-            raise TypeError("Parameter to create_water_oil_gas must be a dictionary")
-
-        check_deprecated(params)
-
-        # For case insensitiveness, all keys are converted to lower case:
-        params = {key.lower(): value for (key, value) in params.items()}
-
-        wateroil: Optional[WaterOil]
-        if sufficient_water_oil_params(params, failhard=False):
-            wateroil = PyscalFactory.create_water_oil(params, fast=fast)
-        else:
-            logger.info("No wateroil parameters. Assuming only gas-oil in wateroilgas")
-            wateroil = None
-
-        # If the swl in WaterOil was initialized with swlheight,
-        # ensure that result is passed on to the GasOil object:
-        if "swl" not in params and "swlheight" in params and wateroil is not None:
-            params["swl"] = wateroil.swl
-
-        gasoil: Optional[GasOil]
-        if sufficient_gas_oil_params(params, failhard=False):
-            gasoil = PyscalFactory.create_gas_oil(params, fast=fast)
-        else:
-            logger.info("No gasoil parameters, assuming two-phase oilwatergas")
-            gasoil = None
-
-        wog_init_params = slicedict(params, WOG_INIT)
-        wateroilgas = WaterOilGas(**wog_init_params, fast=fast)
-        # The wateroilgas __init__ has already created WaterOil and GasOil objects
-        # but we overwrite the references with newly created ones, this factory function
-        # must then guarantee that they are compatible.
-        wateroilgas.wateroil = wateroil  # This might be None
-        wateroilgas.gasoil = gasoil  # This might be None
-        if not wateroilgas.selfcheck():
-            raise ValueError(
-                f"Inconsistent WaterOilGas object. Bug? Input was {params}"
+        if tabular_file_format == "csv" and sheet_name is not None:
+            logger.warning(
+                "Sheet name only relevant for XLSX files, ignoring %s", sheet_name
             )
-        return wateroilgas
-
-    @staticmethod
-    def create_gas_water(
-        params: Optional[Dict[str, float]] = None, fast: bool = False
-    ) -> GasWater:
-        """Create a GasWater object.
-
-        Parameterization (Corey/LET) is inferred from presence
-        of certain parameters in the dictionary.
-
-        Args:
-            params: Dictionary with parameters for GasWater.
-            fast: If fast-mode should be set for constructed object.
-        """
-        if not params:
-            params = {}
-        if not isinstance(params, dict):
-            raise TypeError("Parameter to create_gas_water must be a dictionary")
-
-        # For case insensitiveness, all keys are converted to lower case:
-        params = {key.lower(): value for (key, value) in params.items()}
-
-        sufficient_gas_water_params(params, failhard=True)
-
-        gw_init_params = slicedict(params, GW_INIT)
-        gaswater = GasWater(**gw_init_params, fast=fast)
-
-        # We are using the create_water_oil_gas factory function
-        # to avoid replicating code. It works because GasWater and
-        # WaterOilGas internally are very similar.
-        wog_params = params.copy()
-        if "sgrw" in params:
-            wog_params["sorw"] = params["sgrw"]
-        # Set some dummy parameters for oil:
-        wog_params["nog"] = 1
-        wog_params["now"] = 1
-        wog = PyscalFactory.create_water_oil_gas(wog_params, fast=fast)
-        assert wog.wateroil is not None
-        assert wog.gasoil is not None
-        gaswater.wateroil = wog.wateroil
-        gaswater.gasoil = wog.gasoil
-        return gaswater
-
-    @staticmethod
-    def create_scal_recommendation(
-        params: Dict[str, Dict[str, float]],
-        tag: str = "",
-        h: Optional[float] = None,
-        fast: bool = False,
-    ) -> SCALrecommendation:
-        """
-        Set up a SCAL recommendation curve set from input as a
-        dictionary of dictionary.
-
-        The keys in in the dictionary *must* be "low", "base" and "high".
-
-        The value for "low" must be a new dictionary with saturation
-        endpoints and LET/Corey parameters, as you would feed it to
-        the create_water_oil_gas() factory function, and then similarly
-        for base and high.
-
-        For oil-water only, you may omit the parameters for gas-oil.
-        A WaterOilGas object for each case is created, but only the
-        WaterOil part of it will be used.
-
-        For gas-water, a GasWater object is created for each pess, base
-        and high.
-
-        Args:
-            params: keys low, base and high.
-                The value for "low" must be a new dictionary with saturation
-                endpoints and LET/Corey parameters, as you would feed it to
-                the create_water_oil_gas() factory function, and then similarly
-                for base and high.
-            tag: String to be used as the tag, will end up in comments.
-            h: Saturation step length
-            fast: If fast-mode should be set for constructed object.
-        """
-        if not isinstance(params, dict):
-            raise ValueError("Input must be a dictionary (of dictionaries)")
-
-        # For case insensitiveness, all keys are converted to lower case:
-        params = {key.lower(): value for (key, value) in params.items()}
-
-        if "low" not in params:
-            raise ValueError('"low" case not supplied')
-        if "base" not in params:
-            raise ValueError('"base" case not supplied')
-        if "high" not in params:
-            raise ValueError('"high" case not supplied')
-        if not (
-            isinstance(params["low"], dict)
-            and isinstance(params["base"], dict)
-            and isinstance(params["high"], dict)
-        ):
-            raise ValueError("All values in parameter dict must be dictionaries")
-
-        check_deprecated(params["low"])
-        check_deprecated(params["base"])
-        check_deprecated(params["high"])
-
-        errored = False
-        if h is not None:
-            params["low"]["h"] = h
-            params["base"]["h"] = h
-            params["high"]["h"] = h
-
-        # Check parameter availability, in order to determine phase configuration
-        gaswater = all(
-            sufficient_gas_water_params(params[case]) for case in params.keys()
-        )
-        gasoil = all(sufficient_gas_oil_params(params[case]) for case in params.keys())
-        wateroil = all(
-            sufficient_water_oil_params(params[case]) for case in params.keys()
-        )
-
-        wog_low: Union[WaterOilGas, GasWater]
-        wog_base: Union[WaterOilGas, GasWater]
-        wog_high: Union[WaterOilGas, GasWater]
-
-        if wateroil or gasoil:
+        excel_engines = {"xls": "xlrd", "xlsx": "openpyxl"}
+        if tabular_file_format != "csv" and sheet_name:
             try:
-                wog_low = PyscalFactory.create_water_oil_gas(params["low"], fast=fast)
-            except ValueError as err:
-                raise ValueError(f"Problem with low/pess case: {err}") from err
-            try:
-                wog_base = PyscalFactory.create_water_oil_gas(params["base"], fast=fast)
-            except ValueError as err:
-                raise ValueError(f"Problem with base case: {err}") from err
-            try:
-                wog_high = PyscalFactory.create_water_oil_gas(params["high"], fast=fast)
-            except ValueError as err:
-                raise ValueError(f"Problem with high/opt case: {err}") from err
-        elif gaswater:
-            # Note that gaswater will be True in three-phase configs.
-            try:
-                wog_low = PyscalFactory.create_gas_water(params["low"], fast=fast)
-            except ValueError as err:
-                raise ValueError(f"Problem with low/pess case: {err}") from err
-            try:
-                wog_base = PyscalFactory.create_gas_water(params["base"], fast=fast)
-            except ValueError as err:
-                raise ValueError(f"Problem with base case: {err}") from err
-            try:
-                wog_high = PyscalFactory.create_gas_water(params["high"], fast=fast)
-            except ValueError as err:
-                raise ValueError(f"Problem with high/opt case: {err}") from err
-
-        errored = all(not wog.selfcheck() for wog in [wog_low, wog_base, wog_high])
-
-        if errored:
-            raise ValueError("Incomplete SCAL recommendation")
-
-        scal = SCALrecommendation(wog_low, wog_base, wog_high, tag)
-        return scal
-
-    @staticmethod
-    def load_relperm_df(
-        inputfile: Union[str, pd.DataFrame], sheet_name: Optional[str] = None
-    ) -> pd.DataFrame:
-        """Read CSV or XLSX from file and return scal/relperm data
-        a dataframe.
-
-        Checks validity in SATNUM and CASE columns.
-        Ensures case-insensitiveness SATNUM, CASE, TAG and COMMENT
-
-        Merges COMMENT into TAG column, as only TAG is picked up downstream.
-        Adds a prefix "SATNUM <number>" to all tags.
-
-        All strings in CASE column are converted to lowercase. Applies
-        aliasing in the CASE column so that "pessimistic" and "pess" map to
-        "low", and "optimistic" and "opt" map to "high".
-
-        Args:
-            inputfile: Filename for XLSX or CSV file, or a
-                pandas DataFrame.
-            sheet_name: Sheet-name, only used when loading xlsx files.
-
-        Returns:
-            To be handed over to pyscal list factory methods.
-            Empty dataframe in case of errors (messages will be logged).
-        """
-        if isinstance(inputfile, (str, Path)) and Path(inputfile).is_file():
-            tabular_file_format = infer_tabular_file_format(inputfile)
-            if not tabular_file_format:
-                raise ValueError(
-                    f"Impossible to infer file format for {inputfile}, not CSV/XLS/XLSX"
-                )
-
-            if tabular_file_format == "csv" and sheet_name is not None:
-                logger.warning(
-                    "Sheet name only relevant for XLSX files, ignoring %s", sheet_name
-                )
-            excel_engines = {"xls": "xlrd", "xlsx": "openpyxl"}
-            if tabular_file_format != "csv" and sheet_name:
-                try:
-                    input_df = pd.read_excel(
-                        inputfile,
-                        sheet_name=sheet_name,
-                        engine=excel_engines[tabular_file_format],
-                    )
-                    logger.info(
-                        "Parsed %s file %s, sheet %s",
-                        tabular_file_format.upper(),
-                        inputfile,
-                        sheet_name,
-                    )
-                except (KeyError, ValueError) as err:
-                    raise ValueError(
-                        f"Non-existing sheet-name {sheet_name} provided."
-                    ) from err
-            elif tabular_file_format.startswith("xls"):
                 input_df = pd.read_excel(
-                    inputfile, engine=excel_engines[tabular_file_format]
+                    inputfile,
+                    sheet_name=sheet_name,
+                    engine=excel_engines[tabular_file_format],
                 )
-                logger.info("Parsed %s file %s", tabular_file_format.upper(), inputfile)
-            else:
-                input_df = pd.read_csv(
-                    inputfile, skipinitialspace=True, encoding="utf-8"
+                logger.info(
+                    "Parsed %s file %s, sheet %s",
+                    tabular_file_format.upper(),
+                    inputfile,
+                    sheet_name,
                 )
-                logger.info("Parsed CSV file %s", inputfile)
-
-        elif isinstance(inputfile, pd.DataFrame):
-            input_df = inputfile
-        else:
-            if isinstance(inputfile, str) and not Path(inputfile).is_file():
-                raise IOError("File not found " + str(inputfile))
-            raise ValueError("Unsupported argument " + str(inputfile))
-        assert isinstance(input_df, pd.DataFrame)
-
-        if input_df.empty:
-            logger.error("Relperm input dataframe is empty!")
-
-        # We will ignore case on the column names, solved by converting column
-        # name to uppercase
-        ignorecasecolumns = ["satnum", "case", "tag", "comment"]
-        for colname in input_df.columns:
-            if colname.lower() in ignorecasecolumns:
-                input_df.rename(
-                    {colname: colname.upper()}, axis="columns", inplace=True
-                )
-
-        # Support both TAG and COLUMN (as TAG)
-        if "COMMENT" in input_df and "TAG" not in input_df:
-            input_df.rename({"COMMENT": "TAG"}, axis="columns", inplace=True)
-        if "COMMENT" in input_df and "TAG" in input_df:
-            # It might never happen that a user puts both tag and comment in
-            # the dataframe, but if so, merge them.
-            input_df["TAG"] = (
-                "tag: " + input_df["TAG"] + "; comment: " + input_df["COMMENT"]
+            except (KeyError, ValueError) as err:
+                raise ValueError(
+                    f"Non-existing sheet-name {sheet_name} provided."
+                ) from err
+        elif tabular_file_format.startswith("xls"):
+            input_df = pd.read_excel(
+                inputfile, engine=excel_engines[tabular_file_format]
             )
+            logger.info("Parsed %s file %s", tabular_file_format.upper(), inputfile)
+        else:
+            input_df = pd.read_csv(inputfile, skipinitialspace=True, encoding="utf-8")
+            logger.info("Parsed CSV file %s", inputfile)
 
-        # It is tempting to detect any NaN's at this point because that can
-        # indicate merged cells, which is not supported, but that could
-        # break optional comment columns which might only be defined on certain lines.
-        if "SATNUM" not in input_df:
-            raise ValueError("SATNUM must be present in CSV/XLSX file/dataframe")
+    elif isinstance(inputfile, pd.DataFrame):
+        input_df = inputfile
+    else:
+        if isinstance(inputfile, str) and not Path(inputfile).is_file():
+            raise IOError("File not found " + str(inputfile))
+        raise ValueError("Unsupported argument " + str(inputfile))
+    assert isinstance(input_df, pd.DataFrame)
 
-        # Delete columns and rows that are all NaNs (this has been observed
-        # to occur from seemingly empty cells in Excel/LibreOffice and
-        # has been seen to vary with Pandas/Openpyxl versions in use)
-        input_df.dropna(axis="columns", how="all", inplace=True)
-        input_df.dropna(axis="index", how="all", inplace=True)
+    if input_df.empty:
+        logger.error("Relperm input dataframe is empty!")
 
-        if input_df["SATNUM"].isnull().sum() > 0:
+    # We will ignore case on the column names, solved by converting column
+    # name to uppercase
+    ignorecasecolumns = ["satnum", "case", "tag", "comment"]
+    for colname in input_df.columns:
+        if colname.lower() in ignorecasecolumns:
+            input_df.rename({colname: colname.upper()}, axis="columns", inplace=True)
+
+    # Support both TAG and COLUMN (as TAG)
+    if "COMMENT" in input_df and "TAG" not in input_df:
+        input_df.rename({"COMMENT": "TAG"}, axis="columns", inplace=True)
+    if "COMMENT" in input_df and "TAG" in input_df:
+        # It might never happen that a user puts both tag and comment in
+        # the dataframe, but if so, merge them.
+        input_df["TAG"] = (
+            "tag: " + input_df["TAG"] + "; comment: " + input_df["COMMENT"]
+        )
+
+    # It is tempting to detect any NaN's at this point because that can
+    # indicate merged cells, which is not supported, but that could
+    # break optional comment columns which might only be defined on certain lines.
+    if "SATNUM" not in input_df:
+        raise ValueError("SATNUM must be present in CSV/XLSX file/dataframe")
+
+    # Delete columns and rows that are all NaNs (this has been observed
+    # to occur from seemingly empty cells in Excel/LibreOffice and
+    # has been seen to vary with Pandas/Openpyxl versions in use)
+    input_df.dropna(axis="columns", how="all", inplace=True)
+    input_df.dropna(axis="index", how="all", inplace=True)
+
+    if input_df["SATNUM"].isnull().sum() > 0:
+        raise ValueError(
+            "Found not-a-number in the SATNUM column. This could be due to "
+            "merged cells in XLSX, which is not supported."
+        )
+
+    # Warn about any other columns with empty cells:
+    nan_columns = set(input_df.columns[input_df.isnull().any()])
+    allowed_nan_columns = set(["COMMENT"])
+    if nan_columns - allowed_nan_columns:
+        logger.warning(
+            "Found empty cells in these columns, this might create trouble: %s",
+            str(nan_columns - allowed_nan_columns),
+        )
+
+    # Check that SATNUM's are consecutive and integers:
+    try:
+        input_df["SATNUM"] = input_df["SATNUM"].astype(int)
+    except ValueError as err:
+        raise ValueError("SATNUM must contain only integers") from err
+
+    if min(input_df["SATNUM"]) != 1:
+        raise ValueError("SATNUM must start at 1")
+
+    if max(input_df["SATNUM"]) != len(input_df["SATNUM"].unique()):
+        raise ValueError(
+            "Missing SATNUMs? Max SATNUM is not equal to number of unique SATNUMS"
+        )
+    if "CASE" not in input_df and len(input_df["SATNUM"].unique()) != len(input_df):
+        raise ValueError("Non-unique SATNUMs?")
+    # If we are in a SCAL recommendation setting
+    if "CASE" in input_df:
+        # Enforce lower case:
+        if input_df["CASE"].isnull().sum() > 0:
             raise ValueError(
-                "Found not-a-number in the SATNUM column. This could be due to "
+                "Found not-a-number in the CASE column. This could be due "
                 "merged cells in XLSX, which is not supported."
             )
+        input_df["CASE"] = remap_validate_cases(input_df["CASE"].values)
 
-        # Warn about any other columns with empty cells:
-        nan_columns = set(input_df.columns[input_df.isnull().any()])
-        allowed_nan_columns = set(["COMMENT"])
-        if nan_columns - allowed_nan_columns:
-            logger.warning(
-                "Found empty cells in these columns, this might create trouble: %s",
-                str(nan_columns - allowed_nan_columns),
-            )
+    # Add the SATNUM index to the TAG column
+    if "TAG" not in input_df:
+        input_df["TAG"] = ""
+    input_df["TAG"].fillna(value="", inplace=True)  # Empty cells to empty string.
+    input_df["TAG"] = "SATNUM " + input_df["SATNUM"].astype(str) + " " + input_df["TAG"]
 
-        # Check that SATNUM's are consecutive and integers:
+    # Check if fast is defined as a column
+    if "fast" in input_df:
+        logger.warning("Fast mode is not an option for individual SATNUMs")
+        logger.warning("it is implemented as a global option.")
+        logger.warning("The fast column in the dataframe will be ignored.")
+        logger.warning("Use fast=True in the function call instead.")
+        logger.warning("Fast mode is only available through the Python API")
+
+    # Check that we are able to make something out of the first row:
+    firstrow = input_df.iloc[0, :]
+    error: bool = False
+    wo_ok = sufficient_water_oil_params(firstrow)
+    go_ok = sufficient_gas_oil_params(firstrow)
+    gw_ok = sufficient_gas_water_params(firstrow)
+    if error or not wo_ok and not go_ok and not gw_ok:
+        raise ValueError(
+            "Can't make neither WaterOil, GasOil or GasWater from "
+            "the given data. Check documentation for what you need to supply. "
+            f"You provided the columns {input_df.columns.values}"
+        )
+    logger.info(
+        "Loaded input data with %s SATNUMS, column %s",
+        str(len(input_df["SATNUM"].unique())),
+        str(input_df.columns.values),
+    )
+    return input_df.sort_values("SATNUM")
+
+
+def alias_sgrw(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Allow sgrw as an alias for sorw by remapping a
+    sgrw value to a sorw value in an incoming dict.
+
+    Will error hard of sorw already exists and is not nan.
+
+    This aliasing is relevant when GasWater is modelled
+    as three-phase to allow for condensate forming, and mirrors
+    GasWater.__init__() which performs the same aliasing.
+
+    Args:
+        params: Keys must be lower case.
+    """
+    if "sgrw" in params:
+        if "sorw" not in params or pd.isnull(params["sorw"]):
+            params_copy = dict(params)
+            params_copy["sorw"] = params["sgrw"]
+            del params_copy["sgrw"]
+            return params_copy
+        if np.isclose(params["sgrw"], params["sorw"]):
+            params_copy = dict(params)
+            del params_copy["sgrw"]
+            return params_copy
+        raise ValueError(
+            f"sgrw ({params['sgrw']}) must equal sorw ({params['sorw']}) "
+            "when both are supplied to WaterOil."
+        )
+    return params
+
+
+def remap_validate_cases(casevalues: List[str]) -> List[str]:
+    """Remap values in the CASE column so that we can use aliases.
+
+    All values are first made lower case, then
+    "pessimistic" and "pess" are mapped to "low" and
+    "optimistic" and "opt" are mapped to "high".
+
+    Will raise ValueError if some values are not understood, and
+    if we don't have exactly three unique values.
+
+    Args:
+        casevalues: values to remap.
+    """
+    accepted = ["low", "base", "high"]
+    aliases = {
+        "pessimistic": "low",
+        "pess": "low",
+        "optimistic": "high",
+        "opt": "high",
+    }
+    lowered = [value.lower() for value in casevalues]
+    remapped = [aliases.get(value, value) for value in lowered]
+    not_understood = set(remapped) - set(accepted)
+    if not_understood:
+        raise ValueError(f"Invalid case values: {not_understood}")
+    if len(set(remapped)) != len(accepted):
+        raise ValueError(
+            f"You must supply low, base AND high, got only {set(remapped)}"
+        )
+    return remapped
+
+
+def create_scal_recommendation_list(
+    input_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
+) -> PyscalList:
+    """Requires SATNUM and CASE to be defined in the input data
+
+    Args:
+        input_df: Input data, should have been processed
+            through load_relperm_df().
+        h: Saturation step-value
+        fast: If fast-mode should be set for constructed object
+
+    Returns:
+        PyscalList, consisting of SCALrecommendation objects
+    """
+    scal_l = PyscalList()
+    assert isinstance(input_df, pd.DataFrame)
+
+    scalinput = input_df.set_index(["SATNUM", "CASE"])
+
+    for satnum in scalinput.index.levels[0].values:
+        # load_relperm_df only validates the CASE column for all SATNUMs at
+        # once, errors for particular SATNUMs are caught here.
+        if len(scalinput.loc[satnum, :]) > 3:
+            raise ValueError(f"Too many cases supplied for SATNUM {satnum}")
+        if len(scalinput.loc[satnum, :]) < 3:
+            raise ValueError(f"Too few cases supplied for SATNUM {satnum}")
         try:
-            input_df["SATNUM"] = input_df["SATNUM"].astype(int)
+            scal_l.append(
+                create_scal_recommendation(
+                    scalinput.loc[satnum, :].to_dict(orient="index"), h=h, fast=fast
+                )
+            )
         except ValueError as err:
-            raise ValueError("SATNUM must contain only integers") from err
+            raise ValueError(f"Error for SATNUM {satnum}: {str(err)}") from err
 
-        if min(input_df["SATNUM"]) != 1:
-            raise ValueError("SATNUM must start at 1")
+    return scal_l
 
-        if max(input_df["SATNUM"]) != len(input_df["SATNUM"].unique()):
+
+def create_pyscal_list(
+    relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
+):
+    """Create WaterOilGas, WaterOil, GasOil or GasWater list
+    based on what is available
+
+    Args:
+        relperm_params_df: Input data, should have been processed
+            through load_relperm_df().
+        h: Saturation step-value
+        fast: If fast-mode should be set for constructed object
+
+    Returns:
+        PyscalList, consisting of either WaterOil, GasOil or WaterOilGas objects
+    """
+    params = relperm_params_df.iloc[0, :]  # first row
+    water_oil = sufficient_water_oil_params(params)
+    gas_oil = sufficient_gas_oil_params(params)
+    gas_water = sufficient_gas_water_params(params)
+
+    if water_oil and gas_oil:
+        return create_wateroilgas_list(relperm_params_df, h, fast)
+    if water_oil:
+        return create_wateroil_list(relperm_params_df, h, fast)
+    if gas_oil:
+        return create_gasoil_list(relperm_params_df, h, fast)
+    if gas_water:
+        return create_gaswater_list(relperm_params_df, h, fast)
+    raise ValueError("Could not determine two or three phase from parameters")
+
+
+def create_wateroilgas_list(
+    relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
+) -> PyscalList:
+    """Create a PyscalList with WaterOilGas objects from
+    a dataframe
+
+    Args:
+        relperm_params_df: Input data, should have been processed
+            through load_relperm_df().
+        h: Saturation step-value
+        fast: If fast-mode should be set for constructed object
+
+    Returns:
+        PyscalList, consisting of WaterOilGas objects
+    """
+    wogl = PyscalList()
+    for (row_idx, params) in relperm_params_df.sort_values("SATNUM").iterrows():
+        if h is not None:
+            params["h"] = h
+        try:
+            wogl.append(create_water_oil_gas(params.to_dict(), fast=fast))
+        except (AssertionError, ValueError, TypeError) as err:
+            raise ValueError(f"Error for SATNUM {row_idx+1}: {str(err)}") from err
+    return wogl
+
+
+def create_wateroil_list(
+    relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
+) -> PyscalList:
+    """Create a PyscalList with WaterOil objects from
+    a dataframe
+
+    Args:
+        relperm_params_df: A valid dataframe with
+            WaterOil parameters, processed through load_relperm_df()
+        h: Saturation steplength
+        fast: If fast-mode should be set for constructed object
+
+    Returns:
+        PyscalList, consisting of WaterOil objects
+    """
+    wol = PyscalList()
+    for (_, params) in relperm_params_df.iterrows():
+        if h is not None:
+            params["h"] = h
+        try:
+            wol.append(create_water_oil(params.to_dict(), fast=fast))
+        except (AssertionError, ValueError, TypeError) as err:
             raise ValueError(
-                "Missing SATNUMs? Max SATNUM is not equal to number of unique SATNUMS"
-            )
-        if "CASE" not in input_df and len(input_df["SATNUM"].unique()) != len(input_df):
-            raise ValueError("Non-unique SATNUMs?")
-        # If we are in a SCAL recommendation setting
-        if "CASE" in input_df:
-            # Enforce lower case:
-            if input_df["CASE"].isnull().sum() > 0:
-                raise ValueError(
-                    "Found not-a-number in the CASE column. This could be due "
-                    "merged cells in XLSX, which is not supported."
-                )
-            input_df["CASE"] = PyscalFactory.remap_validate_cases(
-                input_df["CASE"].values
-            )
+                f"Error for SATNUM {params['SATNUM']}: {str(err)}"
+            ) from err
+    return wol
 
-        # Add the SATNUM index to the TAG column
-        if "TAG" not in input_df:
-            input_df["TAG"] = ""
-        input_df["TAG"].fillna(value="", inplace=True)  # Empty cells to empty string.
-        input_df["TAG"] = (
-            "SATNUM " + input_df["SATNUM"].astype(str) + " " + input_df["TAG"]
-        )
 
-        # Check if fast is defined as a column
-        if "fast" in input_df:
-            logger.warning("Fast mode is not an option for individual SATNUMs")
-            logger.warning("it is implemented as a global option.")
-            logger.warning("The fast column in the dataframe will be ignored.")
-            logger.warning("Use fast=True in the function call instead.")
-            logger.warning("Fast mode is only available through the Python API")
+def create_gasoil_list(
+    relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
+) -> PyscalList:
+    """Create a PyscalList with GasOil objects from
+    a dataframe
 
-        # Check that we are able to make something out of the first row:
-        firstrow = input_df.iloc[0, :]
-        error: bool = False
-        wo_ok = sufficient_water_oil_params(firstrow)
-        go_ok = sufficient_gas_oil_params(firstrow)
-        gw_ok = sufficient_gas_water_params(firstrow)
-        if error or not wo_ok and not go_ok and not gw_ok:
+    Args:
+        relperm_params_df: A valid dataframe with GasOil parameters,
+            processed through load_relperm_df()
+        h: Saturation steplength
+        fast: If fast-mode should be set for constructed object
+
+    Returns:
+        PyscalList, consisting of GasOil objects
+    """
+    gol = PyscalList()
+    for (_, params) in relperm_params_df.iterrows():
+        if h is not None:
+            params["h"] = h
+        try:
+            gol.append(create_gas_oil(params.to_dict(), fast=fast))
+        except (AssertionError, ValueError, TypeError) as err:
             raise ValueError(
-                "Can't make neither WaterOil, GasOil or GasWater from "
-                "the given data. Check documentation for what you need to supply. "
-                f"You provided the columns {input_df.columns.values}"
-            )
-        logger.info(
-            "Loaded input data with %s SATNUMS, column %s",
-            str(len(input_df["SATNUM"].unique())),
-            str(input_df.columns.values),
-        )
-        return input_df.sort_values("SATNUM")
+                f"Error for SATNUM {params['SATNUM']}: {str(err)}"
+            ) from err
+    return gol
 
-    @staticmethod
-    def alias_sgrw(params: Dict[str, Any]) -> Dict[str, Any]:
-        """Allow sgrw as an alias for sorw by remapping a
-        sgrw value to a sorw value in an incoming dict.
 
-        Will error hard of sorw already exists and is not nan.
+def create_gaswater_list(
+    relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
+) -> PyscalList:
+    """Create a PyscalList with WaterOilGas objects from
+    a dataframe, to be used for GasWater
 
-        This aliasing is relevant when GasWater is modelled
-        as three-phase to allow for condensate forming, and mirrors
-        GasWater.__init__() which performs the same aliasing.
+    Args:
+        relperm_params_df: A valid dataframe with GasWater
+            parameters, processed through load_relperm_df()
+        h: Saturation steplength
+        fast: If fast-mode should be set for constructed object
 
-        Args:
-            params: Keys must be lower case.
-        """
-        if "sgrw" in params:
-            if "sorw" not in params or pd.isnull(params["sorw"]):
-                params_copy = dict(params)
-                params_copy["sorw"] = params["sgrw"]
-                del params_copy["sgrw"]
-                return params_copy
-            if np.isclose(params["sgrw"], params["sorw"]):
-                params_copy = dict(params)
-                del params_copy["sgrw"]
-                return params_copy
+    Returns:
+        PyscalList, consisting of GasWater objects
+    """
+    gwl = PyscalList()
+    for (_, params) in relperm_params_df.iterrows():
+        if h is not None:
+            params["h"] = h
+        try:
+            gwl.append(create_gas_water(params.to_dict(), fast=fast))
+        except (AssertionError, ValueError, TypeError) as err:
             raise ValueError(
-                f"sgrw ({params['sgrw']}) must equal sorw ({params['sorw']}) "
-                "when both are supplied to WaterOil."
-            )
-        return params
-
-    @staticmethod
-    def remap_validate_cases(casevalues: List[str]) -> List[str]:
-        """Remap values in the CASE column so that we can use aliases.
-
-        All values are first made lower case, then
-        "pessimistic" and "pess" are mapped to "low" and
-        "optimistic" and "opt" are mapped to "high".
-
-        Will raise ValueError if some values are not understood, and
-        if we don't have exactly three unique values.
-
-        Args:
-            casevalues: values to remap.
-        """
-        accepted = ["low", "base", "high"]
-        aliases = {
-            "pessimistic": "low",
-            "pess": "low",
-            "optimistic": "high",
-            "opt": "high",
-        }
-        lowered = [value.lower() for value in casevalues]
-        remapped = [aliases.get(value, value) for value in lowered]
-        not_understood = set(remapped) - set(accepted)
-        if not_understood:
-            raise ValueError(f"Invalid case values: {not_understood}")
-        if len(set(remapped)) != len(accepted):
-            raise ValueError(
-                f"You must supply low, base AND high, got only {set(remapped)}"
-            )
-        return remapped
-
-    @staticmethod
-    def create_scal_recommendation_list(
-        input_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
-    ) -> PyscalList:
-        """Requires SATNUM and CASE to be defined in the input data
-
-        Args:
-            input_df: Input data, should have been processed
-                through load_relperm_df().
-            h: Saturation step-value
-            fast: If fast-mode should be set for constructed object
-
-        Returns:
-            PyscalList, consisting of SCALrecommendation objects
-        """
-        scal_l = PyscalList()
-        assert isinstance(input_df, pd.DataFrame)
-
-        scalinput = input_df.set_index(["SATNUM", "CASE"])
-
-        for satnum in scalinput.index.levels[0].values:
-            # load_relperm_df only validates the CASE column for all SATNUMs at
-            # once, errors for particular SATNUMs are caught here.
-            if len(scalinput.loc[satnum, :]) > 3:
-                raise ValueError(f"Too many cases supplied for SATNUM {satnum}")
-            if len(scalinput.loc[satnum, :]) < 3:
-                raise ValueError(f"Too few cases supplied for SATNUM {satnum}")
-            try:
-                scal_l.append(
-                    PyscalFactory.create_scal_recommendation(
-                        scalinput.loc[satnum, :].to_dict(orient="index"), h=h, fast=fast
-                    )
-                )
-            except ValueError as err:
-                raise ValueError(f"Error for SATNUM {satnum}: {str(err)}") from err
-
-        return scal_l
-
-    @staticmethod
-    def create_pyscal_list(
-        relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
-    ):
-        """Create WaterOilGas, WaterOil, GasOil or GasWater list
-        based on what is available
-
-        Args:
-            relperm_params_df: Input data, should have been processed
-                through load_relperm_df().
-            h: Saturation step-value
-            fast: If fast-mode should be set for constructed object
-
-        Returns:
-            PyscalList, consisting of either WaterOil, GasOil or WaterOilGas objects
-        """
-        params = relperm_params_df.iloc[0, :]  # first row
-        water_oil = sufficient_water_oil_params(params)
-        gas_oil = sufficient_gas_oil_params(params)
-        gas_water = sufficient_gas_water_params(params)
-
-        if water_oil and gas_oil:
-            return PyscalFactory.create_wateroilgas_list(relperm_params_df, h, fast)
-        if water_oil:
-            return PyscalFactory.create_wateroil_list(relperm_params_df, h, fast)
-        if gas_oil:
-            return PyscalFactory.create_gasoil_list(relperm_params_df, h, fast)
-        if gas_water:
-            return PyscalFactory.create_gaswater_list(relperm_params_df, h, fast)
-        raise ValueError("Could not determine two or three phase from parameters")
-
-    @staticmethod
-    def create_wateroilgas_list(
-        relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
-    ) -> PyscalList:
-        """Create a PyscalList with WaterOilGas objects from
-        a dataframe
-
-        Args:
-            relperm_params_df: Input data, should have been processed
-                through load_relperm_df().
-            h: Saturation step-value
-            fast: If fast-mode should be set for constructed object
-
-        Returns:
-            PyscalList, consisting of WaterOilGas objects
-        """
-        wogl = PyscalList()
-        for (row_idx, params) in relperm_params_df.sort_values("SATNUM").iterrows():
-            if h is not None:
-                params["h"] = h
-            try:
-                wogl.append(
-                    PyscalFactory.create_water_oil_gas(params.to_dict(), fast=fast)
-                )
-            except (AssertionError, ValueError, TypeError) as err:
-                raise ValueError(f"Error for SATNUM {row_idx+1}: {str(err)}") from err
-        return wogl
-
-    @staticmethod
-    def create_wateroil_list(
-        relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
-    ) -> PyscalList:
-        """Create a PyscalList with WaterOil objects from
-        a dataframe
-
-        Args:
-            relperm_params_df: A valid dataframe with
-                WaterOil parameters, processed through load_relperm_df()
-            h: Saturation steplength
-            fast: If fast-mode should be set for constructed object
-
-        Returns:
-            PyscalList, consisting of WaterOil objects
-        """
-        wol = PyscalList()
-        for (_, params) in relperm_params_df.iterrows():
-            if h is not None:
-                params["h"] = h
-            try:
-                wol.append(PyscalFactory.create_water_oil(params.to_dict(), fast=fast))
-            except (AssertionError, ValueError, TypeError) as err:
-                raise ValueError(
-                    f"Error for SATNUM {params['SATNUM']}: {str(err)}"
-                ) from err
-        return wol
-
-    @staticmethod
-    def create_gasoil_list(
-        relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
-    ) -> PyscalList:
-        """Create a PyscalList with GasOil objects from
-        a dataframe
-
-        Args:
-            relperm_params_df: A valid dataframe with GasOil parameters,
-                processed through load_relperm_df()
-            h: Saturation steplength
-            fast: If fast-mode should be set for constructed object
-
-        Returns:
-            PyscalList, consisting of GasOil objects
-        """
-        gol = PyscalList()
-        for (_, params) in relperm_params_df.iterrows():
-            if h is not None:
-                params["h"] = h
-            try:
-                gol.append(PyscalFactory.create_gas_oil(params.to_dict(), fast=fast))
-            except (AssertionError, ValueError, TypeError) as err:
-                raise ValueError(
-                    f"Error for SATNUM {params['SATNUM']}: {str(err)}"
-                ) from err
-        return gol
-
-    @staticmethod
-    def create_gaswater_list(
-        relperm_params_df: pd.DataFrame, h: Optional[float] = None, fast: bool = False
-    ) -> PyscalList:
-        """Create a PyscalList with WaterOilGas objects from
-        a dataframe, to be used for GasWater
-
-        Args:
-            relperm_params_df: A valid dataframe with GasWater
-                parameters, processed through load_relperm_df()
-            h: Saturation steplength
-            fast: If fast-mode should be set for constructed object
-
-        Returns:
-            PyscalList, consisting of GasWater objects
-        """
-        gwl = PyscalList()
-        for (_, params) in relperm_params_df.iterrows():
-            if h is not None:
-                params["h"] = h
-            try:
-                gwl.append(PyscalFactory.create_gas_water(params.to_dict(), fast=fast))
-            except (AssertionError, ValueError, TypeError) as err:
-                raise ValueError(
-                    f"Error for SATNUM {params['SATNUM']}: {str(err)}"
-                ) from err
-        return gwl
+                f"Error for SATNUM {params['SATNUM']}: {str(err)}"
+            ) from err
+    return gwl
 
 
 def sufficient_water_oil_params(params: dict, failhard: bool = False) -> bool:

--- a/pyscal/pyscalcli.py
+++ b/pyscal/pyscalcli.py
@@ -16,7 +16,11 @@ from pyscal import (
     getLogger_pyscal,
 )
 
-from .factory import PyscalFactory
+from .factory import (
+    load_relperm_df,
+    create_scal_recommendation_list,
+    create_pyscal_list,
+)
 
 EPILOG = """
 The parameter file should contain a table with at least the column
@@ -203,9 +207,7 @@ def pyscal_main(
         __name__, {"debug": debug, "verbose": verbose, "output": output}
     )
 
-    parametertable = PyscalFactory.load_relperm_df(
-        parametertable, sheet_name=sheet_name
-    )
+    parametertable = load_relperm_df(parametertable, sheet_name=sheet_name)
 
     assert isinstance(parametertable, pd.DataFrame)
     logger.debug("Input data:\n%s", parametertable.to_string(index=False))
@@ -227,9 +229,7 @@ def pyscal_main(
         # Then we should do interpolation
         if int_param_wo is None:
             raise ValueError("No interpolation parameters provided")
-        scalrec_list = PyscalFactory.create_scal_recommendation_list(
-            parametertable, h=delta_s
-        )
+        scalrec_list = create_scal_recommendation_list(parametertable, h=delta_s)
         assert isinstance(scalrec_list[1], SCALrecommendation)
         if scalrec_list[1].type == WaterOilGas:
             logger.info(
@@ -245,7 +245,7 @@ def pyscal_main(
             )
             wog_list = scalrec_list.interpolate(int_param_wo, None, h=delta_s)
     else:
-        wog_list = PyscalFactory.create_pyscal_list(
+        wog_list = create_pyscal_list(
             parametertable, h=delta_s
         )  # can be both water-oil, water-oil-gas, or gas-water
 

--- a/pyscal/pyscalcli.py
+++ b/pyscal/pyscalcli.py
@@ -14,9 +14,6 @@ from pyscal import (
     WaterOilGas,
     __version__,
     getLogger_pyscal,
-)
-
-from .factory import (
     load_relperm_df,
     create_scal_recommendation_list,
     create_pyscal_list,

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -780,9 +780,7 @@ def test_many_nans():
             {"SATNUM": np.nan, "nw": np.nan, "now": np.nan, "Unnamed: 15": np.nan},
         ]
     )
-    wateroil_list = factory.create_pyscal_list(
-        factory.load_relperm_df(nanframe)
-    )
+    wateroil_list = factory.create_pyscal_list(factory.load_relperm_df(nanframe))
     assert len(wateroil_list) == 1
     sat_table_str_ok(wateroil_list.SWOF())
 
@@ -887,9 +885,7 @@ def test_create_pyscal_list():
     with pytest.raises(
         ValueError, match="Could not determine two or three phase from parameters"
     ):
-        factory.create_pyscal_list(
-            basecasedata.drop(["Ew", "Eg"], axis="columns")
-        )
+        factory.create_pyscal_list(basecasedata.drop(["Ew", "Eg"], axis="columns"))
 
 
 def test_scalrecommendation():
@@ -1006,9 +1002,7 @@ def test_check_deprecated_krowgend():
     # If krogend and kroend are both present, krogend is to be silently ignored
     # (random columns are in general accepted and ignored by pyscal)
 
-    gasoil = factory.create_gas_oil(
-        dict(swl=0.1, ng=2, nog=2, krogend=0.4, kroend=0.3)
-    )
+    gasoil = factory.create_gas_oil(dict(swl=0.1, ng=2, nog=2, krogend=0.4, kroend=0.3))
     assert gasoil.table["KROG"].max() == 0.3
 
     wateroil = factory.create_water_oil(
@@ -1092,9 +1086,7 @@ def test_gensatfunc():
 
     # sigma_costau is missing here:
     conf_line_almost_pc = "RELPERM 4 2 1 3 2 1 0.15 0.10 0.5 20 100 0.2 0.22 -0.5"
-    wateroil = factory.create_water_oil(
-        parse_gensatfuncline(conf_line_almost_pc)
-    )
+    wateroil = factory.create_water_oil(parse_gensatfuncline(conf_line_almost_pc))
     swof = wateroil.SWOF()
     # The factory will not recognize the normalized J-function
     # when costau is missing. Any error message would be the responsibility

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -9,7 +9,6 @@ import pytest
 from pyscal import (
     GasOil,
     GasWater,
-    PyscalFactory,
     SCALrecommendation,
     WaterOil,
     WaterOilGas,
@@ -20,21 +19,20 @@ from pyscal.utils.testing import check_table, sat_table_str_ok
 
 def test_factory_wateroil():
     """Test that we can create curves from dictionaries of parameters"""
-    pyscal_factory = PyscalFactory()
 
     # Factory refuses to create incomplete defaulted objects.
     with pytest.raises(ValueError):
-        pyscal_factory.create_water_oil()
+        factory.create_water_oil()
 
     with pytest.raises(TypeError):
         # (it must be a dictionary)
         # pylint: disable=unexpected-keyword-arg
-        pyscal_factory.create_water_oil(swirr=0.01)  # noqa
+        factory.create_water_oil(swirr=0.01)  # noqa
 
     with pytest.raises(TypeError):
-        pyscal_factory.create_water_oil(params="swirr 0.01")
+        factory.create_water_oil(params="swirr 0.01")
 
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(
             swirr=0.01,
             swl=0.1,
@@ -57,7 +55,7 @@ def test_factory_wateroil():
     sat_table_str_ok(wateroil.SWOF())
     sat_table_str_ok(wateroil.SWFN())
 
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(nw=3, now=2, sorw=0.1, krwend=0.2, krwmax=0.5)
     )
     assert isinstance(wateroil, WaterOil)
@@ -70,7 +68,7 @@ def test_factory_wateroil():
 
     # Ambiguous works, but we don't guarantee that this results
     # in LET or Corey.
-    wateroil = pyscal_factory.create_water_oil(dict(nw=3, Lw=2, Ew=2, Tw=2, now=3))
+    wateroil = factory.create_water_oil(dict(nw=3, Lw=2, Ew=2, Tw=2, now=3))
     assert "KRW" in wateroil.table
     assert "Corey" in wateroil.krwcomment or "LET" in wateroil.krwcomment
     check_table(wateroil.table)
@@ -78,7 +76,7 @@ def test_factory_wateroil():
     sat_table_str_ok(wateroil.SWFN())
 
     # Mixing Corey and LET
-    wateroil = pyscal_factory.create_water_oil(dict(Lw=2, Ew=2, Tw=2, krwend=1, now=4))
+    wateroil = factory.create_water_oil(dict(Lw=2, Ew=2, Tw=2, krwend=1, now=4))
     assert isinstance(wateroil, WaterOil)
     assert "KRW" in wateroil.table
     assert wateroil.table["KRW"].max() == 1.0
@@ -87,7 +85,7 @@ def test_factory_wateroil():
     sat_table_str_ok(wateroil.SWOF())
     sat_table_str_ok(wateroil.SWFN())
 
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(Lw=2, Ew=2, Tw=2, Low=3, Eow=3, Tow=3, krwend=0.5)
     )
     assert isinstance(wateroil, WaterOil)
@@ -102,7 +100,7 @@ def test_factory_wateroil():
     sat_table_str_ok(wateroil.SWFN())
 
     # Add capillary pressure
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(swl=0.1, nw=1, now=1, a=2, b=-1, poro_ref=0.2, perm_ref=100, drho=200)
     )
     assert "PC" in wateroil.table
@@ -113,7 +111,7 @@ def test_factory_wateroil():
     sat_table_str_ok(wateroil.SWFN())
 
     # Test that the optional gravity g is picked up:
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(swl=0.1, nw=1, now=1, a=2, b=-1, poro_ref=0.2, perm_ref=100, drho=200, g=0)
     )
     assert "PC" in wateroil.table
@@ -123,7 +121,7 @@ def test_factory_wateroil():
     sat_table_str_ok(wateroil.SWFN())
 
     # Test petrophysical simple J:
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(
             swl=0.1,
             nw=1,
@@ -143,7 +141,7 @@ def test_factory_wateroil():
     sat_table_str_ok(wateroil.SWFN())
 
     # One pc param missing:
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(swl=0.1, nw=1, now=1, a=2, b=-1, perm_ref=100, drho=200, g=0)
     )
     assert "PC" not in wateroil.table
@@ -153,32 +151,32 @@ def test_fast_mode():
     """Test that the fast-flag is passed on to constructed objects
 
     Each object's own test code tests the actual effects of the fast flag"""
-    wateroil = PyscalFactory.create_water_oil({"nw": 2, "now": 2})
+    wateroil = factory.create_water_oil({"nw": 2, "now": 2})
     assert not wateroil.fast
-    wateroil = PyscalFactory.create_water_oil({"nw": 2, "now": 2}, fast=True)
+    wateroil = factory.create_water_oil({"nw": 2, "now": 2}, fast=True)
     assert wateroil.fast
 
-    gasoil = PyscalFactory.create_gas_oil({"ng": 2, "nog": 2})
+    gasoil = factory.create_gas_oil({"ng": 2, "nog": 2})
     assert not gasoil.fast
-    gasoil = PyscalFactory.create_gas_oil({"ng": 2, "nog": 2}, fast=True)
+    gasoil = factory.create_gas_oil({"ng": 2, "nog": 2}, fast=True)
     assert gasoil.fast
 
-    gaswater = PyscalFactory.create_gas_water({"nw": 2, "ng": 2})
+    gaswater = factory.create_gas_water({"nw": 2, "ng": 2})
     assert not gaswater.gasoil.fast
     assert not gaswater.wateroil.fast
-    gaswater = PyscalFactory.create_gas_water({"nw": 2, "ng": 2}, fast=True)
+    gaswater = factory.create_gas_water({"nw": 2, "ng": 2}, fast=True)
     assert gaswater.gasoil.fast
     assert gaswater.wateroil.fast
     assert gaswater.fast
 
-    wateroilgas = PyscalFactory.create_water_oil_gas(
+    wateroilgas = factory.create_water_oil_gas(
         {"nw": 2, "now": 2, "ng": 2, "nog": 2}, fast=True
     )
     assert wateroilgas.fast
     assert wateroilgas.wateroil.fast
     assert wateroilgas.gasoil.fast
 
-    scalrec = PyscalFactory.create_scal_recommendation(
+    scalrec = factory.create_scal_recommendation(
         {
             "low": {"nw": 2, "now": 2, "ng": 2, "nog": 2},
             "base": {"nw": 2, "now": 2, "ng": 2, "nog": 2},
@@ -197,8 +195,7 @@ def test_fast_mode():
 def test_init_with_swlheight():
     """With sufficient parameters, swl will be calculated on the fly
     when initializing the WaterOil object"""
-    pyscal_factory = PyscalFactory()
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(
             swlheight=200,
             nw=1,
@@ -219,11 +216,11 @@ def test_init_with_swlheight():
         match="Can't initialize from SWLHEIGHT without sufficient simple-J parameters",
     ):
         # This should fail because capillary pressure parameters are not provided.
-        pyscal_factory.create_water_oil(dict(swlheight=200, nw=1, now=1))
+        factory.create_water_oil(dict(swlheight=200, nw=1, now=1))
 
     # swcr must be larger than swl:
     with pytest.raises(ValueError, match="lower than computed swl"):
-        pyscal_factory.create_water_oil(
+        factory.create_water_oil(
             dict(
                 swlheight=200,
                 nw=1,
@@ -240,7 +237,7 @@ def test_init_with_swlheight():
 
     # swlheight must be positive:
     with pytest.raises(ValueError, match="swlheight must be larger than zero"):
-        pyscal_factory.create_water_oil(
+        factory.create_water_oil(
             dict(
                 swlheight=-200,
                 nw=1,
@@ -255,7 +252,7 @@ def test_init_with_swlheight():
         )
 
     # If swcr is large enough, it will pass:
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(
             swlheight=200,
             nw=1,
@@ -274,7 +271,7 @@ def test_init_with_swlheight():
     assert "swcr=0.3" in wateroil.SWOF()
 
     # Test that GasWater also can be initialized with swlheight:
-    gaswater = pyscal_factory.create_gas_water(
+    gaswater = factory.create_gas_water(
         dict(
             swlheight=200,
             nw=1,
@@ -297,7 +294,7 @@ def test_init_with_swlheight():
     with pytest.raises(
         ValueError, match="Can't initialize from SWLHEIGHT without sufficient simple-J"
     ):
-        pyscal_factory.create_water_oil(
+        factory.create_water_oil(
             dict(
                 swlheight=200,
                 nw=1,
@@ -315,21 +312,20 @@ def test_relative_swcr():
     """swcr can be initialized relative to swl
 
     Relevant when swl is initialized from swlheight."""
-    pyscal_factory = PyscalFactory()
 
     with pytest.raises(ValueError, match="swl must be provided"):
-        pyscal_factory.create_water_oil(dict(swcr_add=0.1, nw=1, now=1, swirr=0.01))
+        factory.create_water_oil(dict(swcr_add=0.1, nw=1, now=1, swirr=0.01))
     with pytest.raises(ValueError, match="swcr and swcr_add at the same time"):
-        pyscal_factory.create_water_oil(
+        factory.create_water_oil(
             dict(swcr_add=0.1, swcr=0.1, swl=0.1, nw=1, now=1, swirr=0.01)
         )
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(swcr_add=0.1, swl=0.1, nw=1, now=1, swirr=0.01)
     )
     assert wateroil.swcr == 0.2
 
     # Test when relative to swlheight:
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(
             swlheight=200,
             swcr_add=0.01,
@@ -346,7 +342,7 @@ def test_relative_swcr():
     assert np.isclose(wateroil.swl, 0.02480395)
     assert np.isclose(wateroil.swcr, 0.02480395 + 0.01)
 
-    gaswater = pyscal_factory.create_gas_water(
+    gaswater = factory.create_gas_water(
         dict(
             swlheight=200,
             nw=1,
@@ -367,8 +363,7 @@ def test_relative_swcr():
 def test_ambiguity():
     """Test how the factory handles ambiguity between Corey and LET
     parameters"""
-    pyscal_factory = PyscalFactory()
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(swl=0.1, nw=10, Lw=1, Ew=1, Tw=1, now=2, h=0.1, no=2)
     )
     # Corey is picked here.
@@ -378,21 +373,20 @@ def test_ambiguity():
 
 def test_factory_gasoil():
     """Test that we can create curves from dictionaries of parameters"""
-    pyscal_factory = PyscalFactory()
 
     # Factory refuses to create incomplete defaulted objects.
     with pytest.raises(ValueError):
-        pyscal_factory.create_gas_oil()
+        factory.create_gas_oil()
 
     with pytest.raises(TypeError):
         # (this must be a dictionary)
         # pylint: disable=unexpected-keyword-arg
-        pyscal_factory.create_gas_oil(swirr=0.01)  # noqa
+        factory.create_gas_oil(swirr=0.01)  # noqa
 
     with pytest.raises(TypeError):
-        pyscal_factory.create_gas_oil(params="swirr 0.01")
+        factory.create_gas_oil(params="swirr 0.01")
 
-    gasoil = pyscal_factory.create_gas_oil(
+    gasoil = factory.create_gas_oil(
         dict(swirr=0.01, swl=0.1, sgcr=0.05, tag="Good sand", ng=1, nog=2)
     )
     assert isinstance(gasoil, GasOil)
@@ -408,7 +402,7 @@ def test_factory_gasoil():
     assert "Corey krog" in sgof
     assert "Zero capillary pressure" in sgof
 
-    gasoil = pyscal_factory.create_gas_oil(
+    gasoil = factory.create_gas_oil(
         dict(ng=1.2, nog=2, krgend=0.8, krgmax=0.9, kroend=0.6)
     )
     sgof = gasoil.SGOF()
@@ -417,14 +411,14 @@ def test_factory_gasoil():
     assert "krgend=0.8" in sgof
     check_table(gasoil.table)
 
-    gasoil = pyscal_factory.create_gas_oil(dict(ng=1.3, Log=2, Eog=2, Tog=2))
+    gasoil = factory.create_gas_oil(dict(ng=1.3, Log=2, Eog=2, Tog=2))
     sgof = gasoil.SGOF()
     check_table(gasoil.table)
     sat_table_str_ok(sgof)
     assert "Corey krg" in sgof
     assert "LET krog" in sgof
 
-    gasoil = pyscal_factory.create_gas_oil(dict(Lg=1, Eg=1, Tg=1, Log=2, Eog=2, Tog=2))
+    gasoil = factory.create_gas_oil(dict(Lg=1, Eg=1, Tg=1, Log=2, Eog=2, Tog=2))
     sgof = gasoil.SGOF()
     sat_table_str_ok(sgof)
     check_table(gasoil.table)
@@ -437,7 +431,7 @@ def test_factory_wog_gascondensate():
     is the same as wateroilgas, except that we allow for aliasing
     in sgrw=sorw for the underlying WaterOil object, and also there
     are additional parameters sgro and kromax for GasOil."""
-    wcg = PyscalFactory.create_water_oil_gas(
+    wcg = factory.create_water_oil_gas(
         dict(
             nw=2,
             now=3,
@@ -469,19 +463,19 @@ def test_factory_wog_gascondensate():
 
     # Different sorw and sgrw is a hard error:
     with pytest.raises(ValueError, match="must equal"):
-        PyscalFactory.create_water_oil_gas(
+        factory.create_water_oil_gas(
             dict(nw=2, now=3, ng=1, nog=2, sorw=0.2, sgrw=0.1, swl=0.1)
         )
 
     # But it will pass if they both are supplied but are equal:
-    wcg_2 = PyscalFactory.create_water_oil_gas(
+    wcg_2 = factory.create_water_oil_gas(
         dict(nw=2, now=3, ng=1, nog=2, sorw=0.2, sgrw=0.2, swl=0.1)
     )
     assert "sorw=0.2" in wcg_2.SWOF()
 
     # kroend higher than kromax is an error:
     with pytest.raises(AssertionError):
-        PyscalFactory.create_water_oil_gas(
+        factory.create_water_oil_gas(
             dict(
                 nw=2,
                 now=3,
@@ -498,8 +492,7 @@ def test_factory_wog_gascondensate():
 
 def test_factory_go_gascondensate():
     """In gas condensate problems, the sgro and kromax parameters are relevant"""
-    pyscal_factory = PyscalFactory()
-    gasoil = pyscal_factory.create_gas_oil(
+    gasoil = factory.create_gas_oil(
         dict(sgro=0.1, sgcr=0.1, tag="Good sand", ng=1, nog=2, kroend=0.5, kromax=0.9)
     )
     assert isinstance(gasoil, GasOil)
@@ -516,22 +509,21 @@ def test_factory_go_gascondensate():
 
 def test_factory_gaswater():
     """Test that we can create gas-water curves from dictionaries of parameters"""
-    pyscal_factory = PyscalFactory()
 
     # Factory refuses to create incomplete defaulted objects.
     with pytest.raises(ValueError):
-        pyscal_factory.create_gas_water()
+        factory.create_gas_water()
 
     with pytest.raises(TypeError):
         # pylint: disable=unexpected-keyword-arg
-        pyscal_factory.create_gas_water(swirr=0.01)  # noqa
+        factory.create_gas_water(swirr=0.01)  # noqa
 
     with pytest.raises(TypeError):
         # (it must be a dictionary)
         # pylint: disable=unexpected-keyword-arg
-        pyscal_factory.create_gas_water(params="swirr 0.01")
+        factory.create_gas_water(params="swirr 0.01")
 
-    gaswater = pyscal_factory.create_gas_water(
+    gaswater = factory.create_gas_water(
         dict(swirr=0.01, swl=0.03, sgrw=0.1, sgcr=0.15, tag="gassy sand", ng=2, nw=2)
     )
 
@@ -559,7 +551,7 @@ def test_factory_gaswater():
     assert "ng=2" in sgfn
     assert "gassy sand" in sgfn
 
-    gaswater = pyscal_factory.create_gas_water(dict(lg=1, eg=1, tg=1, nw=3))
+    gaswater = factory.create_gas_water(dict(lg=1, eg=1, tg=1, nw=3))
 
     sgfn = gaswater.SGFN()
     swfn = gaswater.SWFN()
@@ -571,21 +563,20 @@ def test_factory_gaswater():
 
 def test_factory_wateroilgas():
     """Test creating discrete cases of WaterOilGas from factory"""
-    pyscal_factory = PyscalFactory()
 
     # Factory refuses to create incomplete defaulted objects.
     with pytest.raises(ValueError):
-        pyscal_factory.create_water_oil_gas()
+        factory.create_water_oil_gas()
 
     with pytest.raises(TypeError):
         # (this must be a dictionary)
         # pylint: disable=unexpected-keyword-arg
-        pyscal_factory.create_water_oil_gas(swirr=0.01)  # noqa
+        factory.create_water_oil_gas(swirr=0.01)  # noqa
 
     with pytest.raises(TypeError):
-        pyscal_factory.create_water_oil_gas(params="swirr 0.01")
+        factory.create_water_oil_gas(params="swirr 0.01")
 
-    wog = pyscal_factory.create_water_oil_gas(dict(nw=2, now=3, ng=1, nog=2.5))
+    wog = factory.create_water_oil_gas(dict(nw=2, now=3, ng=1, nog=2.5))
     swof = wog.SWOF()
     sgof = wog.SGOF()
     sat_table_str_ok(swof)  # sgof code works for swof also currently
@@ -598,7 +589,7 @@ def test_factory_wateroilgas():
     check_table(wog.wateroil.table)
 
     # Some users will mess up lower vs upper case:
-    wog = pyscal_factory.create_water_oil_gas(dict(NW=2, NOW=3, NG=1, nog=2.5))
+    wog = factory.create_water_oil_gas(dict(NW=2, NOW=3, NG=1, nog=2.5))
     swof = wog.SWOF()
     sgof = wog.SGOF()
     sat_table_str_ok(swof)  # sgof code works for swof also currently
@@ -609,22 +600,21 @@ def test_factory_wateroilgas():
     assert "Corey krow" in swof
 
     # Mangling data
-    wateroil = pyscal_factory.create_water_oil_gas(dict(nw=2, now=3, ng=1))
+    wateroil = factory.create_water_oil_gas(dict(nw=2, now=3, ng=1))
     assert wateroil.gasoil is None
 
 
 def test_factory_wateroilgas_deprecated_krowgend():
     """Using long-time deprecated krowend and krogend will fail"""
     with pytest.raises(ValueError):
-        PyscalFactory.create_water_oil_gas(
+        factory.create_water_oil_gas(
             dict(nw=2, now=3, ng=1, nog=2.5, krowend=0.6, krogend=0.7)
         )
 
 
 def test_factory_wateroilgas_wo():
     """Test making only wateroil through the wateroilgas factory"""
-    pyscal_factory = PyscalFactory()
-    wog = pyscal_factory.create_water_oil_gas(
+    wog = factory.create_water_oil_gas(
         dict(nw=2, now=3, kroend=0.5, sorw=0.04, swcr=0.1)
     )
     swof = wog.SWOF()
@@ -639,9 +629,8 @@ def test_factory_wateroilgas_wo():
 
 def test_factory_wateroil_paleooil(caplog):
     """Test making a WaterOil object with socr different from sorw."""
-    pyscal_factory = PyscalFactory()
     sorw = 0.09
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(nw=2, now=3, kroend=0.5, sorw=sorw, socr=sorw + 0.01, swcr=0.1)
     )
     swof = wateroil.SWOF()
@@ -652,7 +641,7 @@ def test_factory_wateroil_paleooil(caplog):
 
     # If socr is close to sorw, socr is reset to sorw.
     for socr in [sorw - 1e-9, sorw, sorw + 1e-9]:
-        wo_socrignored = pyscal_factory.create_water_oil(
+        wo_socrignored = factory.create_water_oil(
             dict(nw=2, now=3, kroend=0.5, sorw=0.09, socr=socr, swcr=0.1)
         )
         swof = wo_socrignored.SWOF()
@@ -661,7 +650,7 @@ def test_factory_wateroil_paleooil(caplog):
         assert "socr was close to sorw, reset to sorw" in caplog.text
 
     with pytest.raises(ValueError, match="socr must be equal to or larger than sorw"):
-        pyscal_factory.create_water_oil(
+        factory.create_water_oil(
             dict(nw=2, now=3, kroend=0.5, sorw=0.09, socr=0.001, swcr=0.1, h=0.1)
         )
 
@@ -672,12 +661,12 @@ def test_load_relperm_df(tmp_path, caplog):
 
     scalfile_xls = testdir / "data/scal-pc-input-example.xlsx"
 
-    scaldata = PyscalFactory.load_relperm_df(scalfile_xls)
+    scaldata = factory.load_relperm_df(scalfile_xls)
     with pytest.raises(IOError):
-        PyscalFactory.load_relperm_df("not-existing-file")
+        factory.load_relperm_df("not-existing-file")
 
     with pytest.raises(ValueError, match="Non-existing sheet-name"):
-        PyscalFactory.load_relperm_df(scalfile_xls, sheet_name="foo")
+        factory.load_relperm_df(scalfile_xls, sheet_name="foo")
 
     assert "SATNUM" in scaldata
     assert "CASE" in scaldata
@@ -685,53 +674,53 @@ def test_load_relperm_df(tmp_path, caplog):
 
     os.chdir(tmp_path)
     scaldata.to_csv("scal-input.csv")
-    scaldata_fromcsv = PyscalFactory.load_relperm_df("scal-input.csv")
+    scaldata_fromcsv = factory.load_relperm_df("scal-input.csv")
     assert "CASE" in scaldata_fromcsv
     assert not scaldata_fromcsv.empty
-    scaldata_fromdf = PyscalFactory.load_relperm_df(scaldata_fromcsv)
+    scaldata_fromdf = factory.load_relperm_df(scaldata_fromcsv)
     assert "CASE" in scaldata_fromdf
     assert "SATNUM" in scaldata_fromdf
     assert len(scaldata_fromdf) == len(scaldata_fromcsv) == len(scaldata)
 
-    scaldata_fromcsv = PyscalFactory.load_relperm_df("scal-input.csv", sheet_name="foo")
+    scaldata_fromcsv = factory.load_relperm_df("scal-input.csv", sheet_name="foo")
     assert "Sheet name only relevant for XLSX files, ignoring foo" in caplog.text
 
     with pytest.raises(ValueError, match="Unsupported argument"):
-        PyscalFactory.load_relperm_df(dict(foo=1))
+        factory.load_relperm_df(dict(foo=1))
 
     # Perturb the dataframe, this should trigger errors
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(scaldata.drop("SATNUM", axis="columns"))
+        factory.load_relperm_df(scaldata.drop("SATNUM", axis="columns"))
     wrongsatnums = scaldata.copy()
     wrongsatnums["SATNUM"] = wrongsatnums["SATNUM"] * 2
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(wrongsatnums)
+        factory.load_relperm_df(wrongsatnums)
     wrongsatnums = scaldata.copy()
     wrongsatnums["SATNUM"] = wrongsatnums["SATNUM"].astype(int)
     wrongsatnums = wrongsatnums[wrongsatnums["SATNUM"] > 2]
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(wrongsatnums)
+        factory.load_relperm_df(wrongsatnums)
     wrongcases = scaldata.copy()
     wrongcases["CASE"] = wrongcases["CASE"] + "ffooo"
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(wrongcases)
+        factory.load_relperm_df(wrongcases)
 
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(scaldata.drop(["Lw", "Lg"], axis="columns"))
+        factory.load_relperm_df(scaldata.drop(["Lw", "Lg"], axis="columns"))
 
     # Insert a NaN, this replicates what happens if cells are merged
     mergedcase = scaldata.copy()
     mergedcase.loc[3, "SATNUM"] = np.nan
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(mergedcase)
+        factory.load_relperm_df(mergedcase)
 
     relpermfile_xls = testdir / "data/relperm-input-example.xlsx"
-    relpermdata = PyscalFactory.load_relperm_df(relpermfile_xls)
+    relpermdata = factory.load_relperm_df(relpermfile_xls)
     assert "TAG" in relpermdata
     assert "SATNUM" in relpermdata
     assert "satnum" not in relpermdata  # always converted to upper-case
     assert len(relpermdata) == 3
-    swof_str = PyscalFactory.create_pyscal_list(relpermdata, h=0.2).SWOF()
+    swof_str = factory.create_pyscal_list(relpermdata, h=0.2).SWOF()
     assert "Åre 1.8" in swof_str
     assert "SATNUM 2" in swof_str  # Autogenerated in SWOF, generated by factory
     assert "SATNUM 3" in swof_str
@@ -740,21 +729,21 @@ def test_load_relperm_df(tmp_path, caplog):
     # Make a dummy text file
     Path("dummy.txt").write_text("foo\nbar, com", encoding="utf8")
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df("dummy.txt")
+        factory.load_relperm_df("dummy.txt")
 
     # Make an empty csv file
     Path("empty.csv").write_text("", encoding="utf8")
     with pytest.raises(ValueError, match="Impossible to infer file format"):
-        PyscalFactory.load_relperm_df("empty.csv")
+        factory.load_relperm_df("empty.csv")
 
     with pytest.raises(ValueError, match="SATNUM must be present"):
-        PyscalFactory.load_relperm_df(pd.DataFrame())
+        factory.load_relperm_df(pd.DataFrame())
 
     # Merge tags and comments if both are supplied
     Path("tagandcomment.csv").write_text(
         "SATNUM,nw,now,tag,comment\n1,1,1,a-tag,a-comment", encoding="utf8"
     )
-    tagandcomment_df = PyscalFactory.load_relperm_df("tagandcomment.csv")
+    tagandcomment_df = factory.load_relperm_df("tagandcomment.csv")
     assert (
         tagandcomment_df["TAG"].values[0] == "SATNUM 1 tag: a-tag; comment: a-comment"
     )
@@ -762,21 +751,21 @@ def test_load_relperm_df(tmp_path, caplog):
     # Missing SATNUMs:
     Path("wrongsatnum.csv").write_text("SATNUM,nw,now\n1,1,1\n3,1,1", encoding="utf8")
     with pytest.raises(ValueError, match="Missing SATNUMs?"):
-        PyscalFactory.load_relperm_df("wrongsatnum.csv")
+        factory.load_relperm_df("wrongsatnum.csv")
 
     # Missing SATNUMs, like merged cells:
     Path("mergedcells.csv").write_text(
         "CASE,SATNUM,nw,now\nlow,,1,1\nlow,1,2,2\nlow,,3,32", encoding="utf8"
     )
     with pytest.raises(ValueError, match="Found not-a-number"):
-        PyscalFactory.load_relperm_df("mergedcells.csv")
+        factory.load_relperm_df("mergedcells.csv")
 
     # Missing SATNUMs, like merged cells:
     Path("mergedcellscase.csv").write_text(
         "CASE,SATNUM,nw,now\n,1,1,1\nlow,1,2,2\n,1,3,32", encoding="utf8"
     )
     with pytest.raises(ValueError, match="Found not-a-number"):
-        PyscalFactory.load_relperm_df("mergedcellscase.csv")
+        factory.load_relperm_df("mergedcellscase.csv")
 
 
 def test_many_nans():
@@ -791,8 +780,8 @@ def test_many_nans():
             {"SATNUM": np.nan, "nw": np.nan, "now": np.nan, "Unnamed: 15": np.nan},
         ]
     )
-    wateroil_list = PyscalFactory.create_pyscal_list(
-        PyscalFactory.load_relperm_df(nanframe)
+    wateroil_list = factory.create_pyscal_list(
+        factory.load_relperm_df(nanframe)
     )
     assert len(wateroil_list) == 1
     sat_table_str_ok(wateroil_list.SWOF())
@@ -812,7 +801,7 @@ def test_xls_factory():
 
     for ((satnum, _), params) in scalinput.iterrows():
         assert satnum
-        wog = PyscalFactory.create_water_oil_gas(params.to_dict())
+        wog = factory.create_water_oil_gas(params.to_dict())
         swof = wog.SWOF()
         assert "LET krw" in swof
         assert "LET krow" in swof
@@ -827,15 +816,15 @@ def test_create_scal_recommendation_list():
     """Test the factory methods for making scalrecommendation lists"""
     testdir = Path(__file__).absolute().parent
     scalfile_xls = testdir / "data/scal-pc-input-example.xlsx"
-    scaldata = PyscalFactory.load_relperm_df(scalfile_xls)
+    scaldata = factory.load_relperm_df(scalfile_xls)
 
-    scalrec_list = PyscalFactory.create_scal_recommendation_list(scaldata)
+    scalrec_list = factory.create_scal_recommendation_list(scaldata)
     assert len(scalrec_list) == 3
     assert scalrec_list.pyscaltype == SCALrecommendation
 
     # Erroneous input:
     with pytest.raises(ValueError, match="Too many cases supplied for SATNUM 2"):
-        PyscalFactory.create_scal_recommendation_list(
+        factory.create_scal_recommendation_list(
             pd.DataFrame(
                 columns=["SATNUM", "CASE", "NW", "NOW"],
                 data=[
@@ -850,7 +839,7 @@ def test_create_scal_recommendation_list():
             )
         )
     with pytest.raises(ValueError, match="Too few cases supplied for SATNUM 2"):
-        PyscalFactory.create_scal_recommendation_list(
+        factory.create_scal_recommendation_list(
             pd.DataFrame(
                 columns=["SATNUM", "CASE", "NW", "NOW"],
                 data=[
@@ -868,27 +857,27 @@ def test_create_pyscal_list():
     """Test the factory methods for making pyscal lists"""
     testdir = Path(__file__).absolute().parent
     scalfile_xls = testdir / "data/scal-pc-input-example.xlsx"
-    scaldata = PyscalFactory.load_relperm_df(scalfile_xls)
+    scaldata = factory.load_relperm_df(scalfile_xls)
     basecasedata = scaldata[scaldata["CASE"] == "base"].reset_index()
-    relpermlist = PyscalFactory.create_pyscal_list(basecasedata)
+    relpermlist = factory.create_pyscal_list(basecasedata)
     assert len(relpermlist) == 3
     assert relpermlist.pyscaltype == WaterOilGas
 
-    wo_list = PyscalFactory.create_pyscal_list(
+    wo_list = factory.create_pyscal_list(
         basecasedata.drop(["Lg", "Eg", "Tg", "Log", "Eog", "Tog"], axis="columns")
     )
 
     assert len(wo_list) == 3
     assert wo_list.pyscaltype == WaterOil
 
-    go_list = PyscalFactory.create_pyscal_list(
+    go_list = factory.create_pyscal_list(
         basecasedata.drop(["Lw", "Ew", "Tw", "Low", "Eow", "Tow"], axis="columns")
     )
 
     assert len(go_list) == 3
     assert go_list.pyscaltype == GasOil
 
-    gw_list = PyscalFactory.create_pyscal_list(
+    gw_list = factory.create_pyscal_list(
         basecasedata.drop(["Low", "Eow", "Tow", "Log", "Eog", "Tog"], axis="columns")
     )
 
@@ -898,24 +887,23 @@ def test_create_pyscal_list():
     with pytest.raises(
         ValueError, match="Could not determine two or three phase from parameters"
     ):
-        PyscalFactory.create_pyscal_list(
+        factory.create_pyscal_list(
             basecasedata.drop(["Ew", "Eg"], axis="columns")
         )
 
 
 def test_scalrecommendation():
     """Testing making SCAL rec from dict of dict."""
-    pyscal_factory = PyscalFactory()
 
     scal_input = {
         "low": {"nw": 2, "now": 4, "ng": 1, "nog": 2},
         "BASE": {"nw": 3, "NOW": 3, "ng": 1, "nog": 2},
         "high": {"nw": 4, "now": 2, "ng": 1, "nog": 3},
     }
-    scal = pyscal_factory.create_scal_recommendation(scal_input)
+    scal = factory.create_scal_recommendation(scal_input)
 
     with pytest.raises(ValueError, match="Input must be a dict"):
-        pyscal_factory.create_scal_recommendation("low")
+        factory.create_scal_recommendation("low")
 
     # (not supported yet to make WaterOil only..)
     interp = scal.interpolate(-0.5)
@@ -931,12 +919,12 @@ def test_scalrecommendation():
         copy1 = scal_input.copy()
         del copy1[case]
         with pytest.raises(ValueError):
-            pyscal_factory.create_scal_recommendation(copy1)
+            factory.create_scal_recommendation(copy1)
 
     go_only = scal_input.copy()
     del go_only["low"]["now"]
     del go_only["low"]["nw"]
-    gasoil = pyscal_factory.create_scal_recommendation(go_only)
+    gasoil = factory.create_scal_recommendation(go_only)
     assert gasoil.low.wateroil is None
     assert gasoil.base.wateroil is not None
     assert gasoil.high.wateroil is not None
@@ -948,32 +936,31 @@ def test_scalrecommendation():
     basehigh = scal_input.copy()
     del basehigh["low"]
     with pytest.raises(ValueError, match='"low" case not supplied'):
-        pyscal_factory.create_scal_recommendation(basehigh)
+        factory.create_scal_recommendation(basehigh)
 
     baselow = scal_input.copy()
     del baselow["high"]
     with pytest.raises(ValueError, match='"high" case not supplied'):
-        pyscal_factory.create_scal_recommendation(baselow)
+        factory.create_scal_recommendation(baselow)
 
     with pytest.raises(
         ValueError, match="All values in parameter dict must be dictionaries"
     ):
 
-        pyscal_factory.create_scal_recommendation(
+        factory.create_scal_recommendation(
             {"low": [1, 2], "base": {"swl": 0.1}, "high": {"swl": 0.1}}
         )
 
 
 def test_scalrecommendation_gaswater():
     """Testing making SCAL rec from dict of dict for gaswater input"""
-    pyscal_factory = PyscalFactory()
 
     scal_input = {
         "low": {"nw": 2, "ng": 1},
         "BASE": {"nw": 3, "ng": 1},
         "high": {"nw": 4, "ng": 1},
     }
-    scal = pyscal_factory.create_scal_recommendation(scal_input, h=0.2)
+    scal = factory.create_scal_recommendation(scal_input, h=0.2)
     interp = scal.interpolate(-0.5, h=0.2)
     sat_table_str_ok(interp.SWFN())
     sat_table_str_ok(interp.SGFN())
@@ -989,7 +976,7 @@ def test_xls_scalrecommendation():
     scalinput = pd.read_excel(xlsxfile, engine="openpyxl").set_index(["SATNUM", "CASE"])
     for satnum in scalinput.index.levels[0].values:
         dictofdict = scalinput.loc[satnum, :].to_dict(orient="index")
-        scalrec = PyscalFactory.create_scal_recommendation(dictofdict)
+        scalrec = factory.create_scal_recommendation(dictofdict)
         scalrec.interpolate(+0.5)
 
 
@@ -1001,7 +988,7 @@ def test_no_gasoil():
     Make sure we fail in that case."""
     dframe = pd.DataFrame(columns=["SATNUM", "NOW", "NG"], data=[[1, 2, 2]])
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(dframe)
+        factory.load_relperm_df(dframe)
 
 
 def test_check_deprecated_krowgend():
@@ -1011,20 +998,20 @@ def test_check_deprecated_krowgend():
     After pyscal 0.8 presence of krogend and krowend is a ValueError
     """
     with pytest.raises(ValueError):
-        PyscalFactory.create_water_oil(dict(swl=0.1, nw=2, now=2, krowend=0.4))
+        factory.create_water_oil(dict(swl=0.1, nw=2, now=2, krowend=0.4))
 
     with pytest.raises(ValueError):
-        PyscalFactory.create_gas_oil(dict(swl=0.1, ng=2, nog=2, krogend=0.4))
+        factory.create_gas_oil(dict(swl=0.1, ng=2, nog=2, krogend=0.4))
 
     # If krogend and kroend are both present, krogend is to be silently ignored
     # (random columns are in general accepted and ignored by pyscal)
 
-    gasoil = PyscalFactory.create_gas_oil(
+    gasoil = factory.create_gas_oil(
         dict(swl=0.1, ng=2, nog=2, krogend=0.4, kroend=0.3)
     )
     assert gasoil.table["KROG"].max() == 0.3
 
-    wateroil = PyscalFactory.create_water_oil(
+    wateroil = factory.create_water_oil(
         dict(swl=0.1, nw=2, now=2, krowend=0.4, kroend=0.3)
     )
     assert wateroil.table["KROW"].max() == 0.3
@@ -1084,12 +1071,10 @@ def test_gensatfunc():
     """Test how the external tool gen_satfunc could use
     the factory functionality"""
 
-    pyscal_factory = PyscalFactory()
-
     # Example config line for gen_satfunc:
     conf_line_pc = "RELPERM 4 2 1 3 2 1 0.15 0.10 0.5 20 100 0.2 0.22 -0.5 30"
 
-    wateroil = pyscal_factory.create_water_oil(parse_gensatfuncline(conf_line_pc))
+    wateroil = factory.create_water_oil(parse_gensatfuncline(conf_line_pc))
     swof = wateroil.SWOF()
     assert "0.17580" in swof  # krw at sw=0.65
     assert "0.0127" in swof  # krow at sw=0.65
@@ -1097,7 +1082,7 @@ def test_gensatfunc():
     assert "2.0669" in swof  # pc at swl
 
     conf_line_min = "RELPERM 1 2 3 1 2 3 0.1 0.15 0.5 20"
-    wateroil = pyscal_factory.create_water_oil(parse_gensatfuncline(conf_line_min))
+    wateroil = factory.create_water_oil(parse_gensatfuncline(conf_line_min))
     swof = wateroil.SWOF()
     assert "Zero capillary pressure" in swof
 
@@ -1107,7 +1092,7 @@ def test_gensatfunc():
 
     # sigma_costau is missing here:
     conf_line_almost_pc = "RELPERM 4 2 1 3 2 1 0.15 0.10 0.5 20 100 0.2 0.22 -0.5"
-    wateroil = pyscal_factory.create_water_oil(
+    wateroil = factory.create_water_oil(
         parse_gensatfuncline(conf_line_almost_pc)
     )
     swof = wateroil.SWOF()
@@ -1178,8 +1163,8 @@ def test_case_aliasing():
             [1, "opt", 3, 1, 1, 1],
         ],
     )
-    relperm_data = PyscalFactory.load_relperm_df(dframe)
-    PyscalFactory.create_scal_recommendation_list(relperm_data, h=0.2).interpolate(-0.4)
+    relperm_data = factory.load_relperm_df(dframe)
+    factory.create_scal_recommendation_list(relperm_data, h=0.2).interpolate(-0.4)
     dframe = pd.DataFrame(
         columns=["SATNUM", "CASE", "Nw", "Now", "Ng", "Nog"],
         data=[
@@ -1188,11 +1173,11 @@ def test_case_aliasing():
             [1, "optiMISTIc", 3, 1, 1, 1],
         ],
     )
-    relperm_data = PyscalFactory.load_relperm_df(dframe)
-    PyscalFactory.create_scal_recommendation_list(relperm_data, h=0.2).interpolate(-0.4)
+    relperm_data = factory.load_relperm_df(dframe)
+    factory.create_scal_recommendation_list(relperm_data, h=0.2).interpolate(-0.4)
 
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(
+        factory.load_relperm_df(
             pd.DataFrame(
                 columns=["SATNUM", "CASE", "Nw", "Now", "Ng", "Nog"],
                 data=[
@@ -1205,7 +1190,7 @@ def test_case_aliasing():
 
     # Ambigous data:
     with pytest.raises(ValueError):
-        amb = PyscalFactory.load_relperm_df(
+        amb = factory.load_relperm_df(
             pd.DataFrame(
                 columns=["SATNUM", "CASE", "Nw", "Now", "Ng", "Nog"],
                 data=[
@@ -1216,11 +1201,11 @@ def test_case_aliasing():
                 ],
             )
         )
-        PyscalFactory.create_scal_recommendation_list(amb)
+        factory.create_scal_recommendation_list(amb)
 
     # Missing a case
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(
+        factory.load_relperm_df(
             pd.DataFrame(
                 columns=["SATNUM", "CASE", "Nw", "Now", "Ng", "Nog"],
                 data=[[1, "base", 3, 1, 1, 1], [1, "optIMIstiC", 3, 1, 1, 1]],
@@ -1228,7 +1213,7 @@ def test_case_aliasing():
         )
     # Missing a case
     with pytest.raises(ValueError):
-        PyscalFactory.load_relperm_df(
+        factory.load_relperm_df(
             pd.DataFrame(
                 columns=["SATNUM", "CASE", "Nw", "Now", "Ng", "Nog"],
                 data=[[1, "base", 3, 1, 1, 1]],
@@ -1238,8 +1223,8 @@ def test_case_aliasing():
 
 def test_socr_via_dframe():
     """Test that the "socr" parameter is picked up from a dataframe/xlsx input"""
-    p_list = PyscalFactory.create_pyscal_list(
-        PyscalFactory.load_relperm_df(
+    p_list = factory.create_pyscal_list(
+        factory.load_relperm_df(
             pd.DataFrame(
                 columns=["SATNUM", "Nw", "Now", "socr"],
                 data=[[1, 2, 2, 0.5]],
@@ -1270,15 +1255,15 @@ def test_swirr_partially_missing(tmp_path):
             [2, 3, 3, 0.1, np.nan, np.nan, np.nan, np.nan, np.nan],
         ],
     )
-    relperm_data = PyscalFactory.load_relperm_df(dframe)
-    p_list = PyscalFactory.create_pyscal_list(relperm_data, h=0.2)
+    relperm_data = factory.load_relperm_df(dframe)
+    p_list = factory.create_pyscal_list(relperm_data, h=0.2)
     assert "a=2, b=-2" in p_list[1].pccomment
     assert p_list[2].pccomment == ""
 
     os.chdir(tmp_path)
     dframe.to_excel("partial_pc.xlsx")
-    relperm_data_via_xlsx = PyscalFactory.load_relperm_df("partial_pc.xlsx")
-    p_list = PyscalFactory.create_pyscal_list(relperm_data_via_xlsx, h=0.2)
+    relperm_data_via_xlsx = factory.load_relperm_df("partial_pc.xlsx")
+    p_list = factory.create_pyscal_list(relperm_data_via_xlsx, h=0.2)
     assert "a=2, b=-2" in p_list[1].pccomment
     assert p_list[2].pccomment == ""
 
@@ -1290,8 +1275,8 @@ def test_corey_let_mix():
         columns=["SATNUM", "Nw", "Now", "Lw", "Ew", "Tw", "Ng", "Nog"],
         data=[[1, 2, 2, np.nan, np.nan, np.nan, 1, 1], [2, np.nan, 3, 1, 1, 1, 2, 2]],
     )
-    relperm_data = PyscalFactory.load_relperm_df(dframe)
-    p_list = PyscalFactory.create_pyscal_list(relperm_data, h=0.2)
+    relperm_data = factory.load_relperm_df(dframe)
+    p_list = factory.create_pyscal_list(relperm_data, h=0.2)
     swof1 = p_list.pyscal_list[0].SWOF()
     swof2 = p_list.pyscal_list[1].SWOF()
     assert "Corey krw" in swof1

--- a/tests/test_interactive_plots.py
+++ b/tests/test_interactive_plots.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from matplotlib import pyplot
 
-from pyscal import GasOil, GasWater, factory, WaterOil, utils
+from pyscal import GasOil, GasWater, create_scal_recommendation, WaterOil, utils
 
 from .test_scalrecommendation import BASE_SAMPLE_LET, HIGH_SAMPLE_LET, LOW_SAMPLE_LET
 
@@ -313,7 +313,7 @@ def test_SCAL_interpolation():
     # pylint: disable=invalid-name
     matplotlib.style.use("ggplot")
 
-    rec = factory.create_scal_recommendation(
+    rec = create_scal_recommendation(
         {"low": LOW_SAMPLE_LET, "base": BASE_SAMPLE_LET, "high": HIGH_SAMPLE_LET},
         "FOO",
         h=0.001,

--- a/tests/test_interactive_plots.py
+++ b/tests/test_interactive_plots.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from matplotlib import pyplot
 
-from pyscal import GasOil, GasWater, PyscalFactory, WaterOil, utils
+from pyscal import GasOil, GasWater, factory, WaterOil, utils
 
 from .test_scalrecommendation import BASE_SAMPLE_LET, HIGH_SAMPLE_LET, LOW_SAMPLE_LET
 
@@ -313,7 +313,7 @@ def test_SCAL_interpolation():
     # pylint: disable=invalid-name
     matplotlib.style.use("ggplot")
 
-    rec = PyscalFactory.create_scal_recommendation(
+    rec = factory.create_scal_recommendation(
         {"low": LOW_SAMPLE_LET, "base": BASE_SAMPLE_LET, "high": HIGH_SAMPLE_LET},
         "FOO",
         h=0.001,

--- a/tests/test_scalrecommendation.py
+++ b/tests/test_scalrecommendation.py
@@ -5,8 +5,14 @@ import pandas as pd
 import pytest
 from hypothesis import given, settings
 
-from pyscal import GasWater, PyscalFactory, SCALrecommendation, WaterOil, WaterOilGas
-from pyscal.factory import slicedict
+from pyscal import GasWater, SCALrecommendation, WaterOil, WaterOilGas
+from pyscal.factory import (
+    create_water_oil_gas,
+    create_scal_recommendation,
+    create_scal_recommendation_list,
+    load_relperm_df,
+    slicedict,
+)
 from pyscal.utils.testing import check_table, sat_table_str_ok
 
 # Example SCAL recommendation, low case
@@ -92,9 +98,9 @@ def test_make_scalrecommendation():
     """Test that we can make scal recommendation objects
     from three WaterOilGas objects"""
 
-    low = PyscalFactory.create_water_oil_gas(LOW_SAMPLE_LET)
-    base = PyscalFactory.create_water_oil_gas(BASE_SAMPLE_LET)
-    high = PyscalFactory.create_water_oil_gas(HIGH_SAMPLE_LET)
+    low = create_water_oil_gas(LOW_SAMPLE_LET)
+    base = create_water_oil_gas(BASE_SAMPLE_LET)
+    high = create_water_oil_gas(HIGH_SAMPLE_LET)
     rec = SCALrecommendation(low, base, high)
     interpolant = rec.interpolate(-0.5, h=0.2)
     check_table(interpolant.wateroil.table)
@@ -142,12 +148,12 @@ def test_make_scalrecommendation_wo(caplog):
     ]
 
     low_let_wo = slicedict(LOW_SAMPLE_LET, wo_param_names)
-    low = PyscalFactory.create_water_oil_gas(low_let_wo)
+    low = create_water_oil_gas(low_let_wo)
     base_let_wo = slicedict(BASE_SAMPLE_LET, wo_param_names)
-    base = PyscalFactory.create_water_oil_gas(base_let_wo)
+    base = create_water_oil_gas(base_let_wo)
     high_let_wo = slicedict(HIGH_SAMPLE_LET, wo_param_names)
     assert "Lg" not in high_let_wo
-    high = PyscalFactory.create_water_oil_gas(high_let_wo)
+    high = create_water_oil_gas(high_let_wo)
     rec = SCALrecommendation(low, base, high)
     interpolant = rec.interpolate(-0.5)
     check_table(interpolant.wateroil.table)
@@ -185,12 +191,12 @@ def test_make_scalrecommendation_go():
     ]
 
     low_let_go = slicedict(LOW_SAMPLE_LET, go_param_names)
-    low = PyscalFactory.create_water_oil_gas(low_let_go)
+    low = create_water_oil_gas(low_let_go)
     base_let_go = slicedict(BASE_SAMPLE_LET, go_param_names)
-    base = PyscalFactory.create_water_oil_gas(base_let_go)
+    base = create_water_oil_gas(base_let_go)
     high_let_go = slicedict(HIGH_SAMPLE_LET, go_param_names)
     assert "Lw" not in high_let_go
-    high = PyscalFactory.create_water_oil_gas(high_let_go)
+    high = create_water_oil_gas(high_let_go)
     rec = SCALrecommendation(low, base, high)
     assert rec.type == WaterOilGas
     interpolant = rec.interpolate(-0.5)
@@ -214,7 +220,7 @@ def test_interpolation(param_wo, param_go):
     """Test interpolation with random interpolation parameters,
     looking for numerical corner cases"""
 
-    rec = PyscalFactory.create_scal_recommendation(
+    rec = create_scal_recommendation(
         {"low": LOW_SAMPLE_LET, "base": BASE_SAMPLE_LET, "high": HIGH_SAMPLE_LET},
         "foo",
         h=0.1,
@@ -247,7 +253,7 @@ def test_interpolation(param_wo, param_go):
 def test_boundary_cases():
     """Test that interpolation is able to return the boundaries
     at +/- 1"""
-    rec = PyscalFactory.create_scal_recommendation(
+    rec = create_scal_recommendation(
         {"low": LOW_SAMPLE_LET, "base": BASE_SAMPLE_LET, "high": HIGH_SAMPLE_LET},
         "foo",
         h=0.1,
@@ -379,9 +385,7 @@ def test_gaswater_scal(caplog):
             [1, "opt", 4, 4, "sometag"],
         ],
     )
-    rec_list = PyscalFactory.create_scal_recommendation_list(
-        PyscalFactory.load_relperm_df(dframe), h=0.1
-    )
+    rec_list = create_scal_recommendation_list(load_relperm_df(dframe), h=0.1)
     assert rec_list.pyscaltype == SCALrecommendation
     assert rec_list[1].type == GasWater
     low_list = rec_list.interpolate(-1)
@@ -404,9 +408,9 @@ def test_gaswater_scal(caplog):
 
 def test_fast():
     """Test the fast option"""
-    low_fast = PyscalFactory.create_water_oil_gas(LOW_SAMPLE_LET, fast=True)
-    base_fast = PyscalFactory.create_water_oil_gas(BASE_SAMPLE_LET, fast=True)
-    high_fast = PyscalFactory.create_water_oil_gas(HIGH_SAMPLE_LET, fast=True)
+    low_fast = create_water_oil_gas(LOW_SAMPLE_LET, fast=True)
+    base_fast = create_water_oil_gas(BASE_SAMPLE_LET, fast=True)
+    high_fast = create_water_oil_gas(HIGH_SAMPLE_LET, fast=True)
 
     rec = SCALrecommendation(low_fast, base_fast, high_fast)
     interp = rec.interpolate(-0.5)
@@ -414,9 +418,9 @@ def test_fast():
     assert interp.fast
 
     # test that one or more inputs not being set to fast does not trigger fast mode
-    low = PyscalFactory.create_water_oil_gas(LOW_SAMPLE_LET)
-    base = PyscalFactory.create_water_oil_gas(BASE_SAMPLE_LET)
-    high = PyscalFactory.create_water_oil_gas(HIGH_SAMPLE_LET)
+    low = create_water_oil_gas(LOW_SAMPLE_LET)
+    base = create_water_oil_gas(BASE_SAMPLE_LET)
+    high = create_water_oil_gas(HIGH_SAMPLE_LET)
 
     rec = SCALrecommendation(low_fast, base_fast, high)
     interp = rec.interpolate(-0.5)

--- a/tests/test_scalrecommendation.py
+++ b/tests/test_scalrecommendation.py
@@ -5,13 +5,16 @@ import pandas as pd
 import pytest
 from hypothesis import given, settings
 
-from pyscal import GasWater, SCALrecommendation, WaterOil, WaterOilGas
-from pyscal.factory import (
+from pyscal import (
+    GasWater,
+    SCALrecommendation,
+    WaterOil,
+    WaterOilGas,
+    slicedict,
     create_water_oil_gas,
     create_scal_recommendation,
     create_scal_recommendation_list,
     load_relperm_df,
-    slicedict,
 )
 from pyscal.utils.testing import check_table, sat_table_str_ok
 


### PR DESCRIPTION
Removed the PyscalFactory class from factory.py such that all the static methods within are now individual functions that can be used and accessed without having reference the PyscalFactory class (all of the references were also removed appropriately).