### PR TITLE
Fix yet another whitespace bug in testkomodo.sh

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,3 +1,3 @@
 install_test_dependencies () {
-￼  pip install -r test_requirements.txt
+  pip install -r test_requirements.txt
 }


### PR DESCRIPTION
This bug was reproduced locally by first sourcing the file (that goes fine), and then try to run the bash-function, then the error pops up:

```
(3.6) [havb@be-lx895926:/work/projects/pyscal] master$ cat ci/jenkins/testkomodo.sh 
install_test_dependencies () {
￼  pip install -r test_requirements.txt
}
(3.6) [havb@be-lx895926:/work/projects/pyscal] master$ install_test_dependencies
bash: ￼: command not found...
```
Indent must apparently be exactly 2, not 3.

Another option is probably to delete this file altogether, as it is doing the same command as the default in komodo.