### PR TITLE
Relax tests after hypothesis bugfix

### DIFF
--- a/tests/test_estimateendpoints.py
+++ b/tests/test_estimateendpoints.py
@@ -128,7 +128,7 @@ def test_linear_corey():
 
 @given(
     st.floats(min_value=0.001, max_value=0.2),
-    st.floats(min_value=0, max_value=0.5),
+    st.floats(min_value=0.0001, max_value=0.5),
     st.floats(min_value=0.5, max_value=3),
 )
 def test_sorw_hypo(h, sorw, nw):

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -169,7 +169,7 @@ def test_gasoil_normalization(swl, sgcr, sorg, h, tag):
     st.floats(min_value=0.1, max_value=1),  # kromax
     st.floats(min_value=0.1, max_value=1),  # krgend
     st.floats(min_value=0.2, max_value=1),  # krgmax
-    st.floats(min_value=0.0001, max_value=1),  # h
+    st.floats(min_value=0.001, max_value=1),  # h
     st.booleans(),  # fast mode
 )
 def test_gasoil_krendmax(

--- a/tests/test_gaswater.py
+++ b/tests/test_gaswater.py
@@ -148,7 +148,7 @@ def test_gaswater_let1(l, e, t, krwend, krwmax):
     st.floats(min_value=0.1, max_value=1),
     st.floats(min_value=0.1, max_value=1),
     st.floats(min_value=0.1, max_value=1),
-    st.floats(min_value=0.0001, max_value=1),
+    st.floats(min_value=0.001, max_value=1),
     st.booleans(),
 )
 def test_gaswater_krendmax(swl, swcr, sgrw, krgend, krwend, krwmax, h, fast):

--- a/tests/test_wateroil.py
+++ b/tests/test_wateroil.py
@@ -105,7 +105,7 @@ def test_wateroil_let1(l, e, t, krwend, krwmax):
     st.floats(min_value=0.1, max_value=1),
     st.floats(min_value=0.1, max_value=1),
     st.floats(min_value=0.1, max_value=1),
-    st.floats(min_value=0.0001, max_value=1),
+    st.floats(min_value=0.001, max_value=1),
     st.booleans(),
 )
 def test_wateroil_krendmax(swl, swcr, sorw, socr_add, kroend, krwend, krwmax, h, fast):

--- a/tests/test_wateroil_saturation.py
+++ b/tests/test_wateroil_saturation.py
@@ -4,7 +4,7 @@ import hypothesis.strategies as st
 from hypothesis import given, settings
 
 from pyscal import WaterOil
-from pyscal.constants import SWINTEGERS
+from pyscal.constants import EPSILON, SWINTEGERS
 from pyscal.utils.testing import check_table, float_df_checker
 
 
@@ -69,35 +69,35 @@ def test_wateroil_normalization(swirr, swl, swcr, sorw, socr_add, h, tag):
     assert float_df_checker(wateroil.table, "SW", 1.0, "SWNPC", 1)
 
 
-@given(st.floats(min_value=0, max_value=1))
+@given(st.floats(min_value=0, max_value=1 - EPSILON))
 def test_wateroil_swir(swirr):
     """Check that the saturation values are valid for all swirr"""
     wateroil = WaterOil(swirr=swirr)
     check_table(wateroil.table)
 
 
-@given(st.floats(min_value=0, max_value=1))
+@given(st.floats(min_value=0, max_value=1 - EPSILON))
 def test_wateroil_swl(swl):
     """Check that the saturation values are valid for all swl"""
     wateroil = WaterOil(swl=swl)
     check_table(wateroil.table)
 
 
-@given(st.floats(min_value=0, max_value=1))
+@given(st.floats(min_value=0, max_value=1 - EPSILON))
 def test_wateroil_swcr(swcr):
     """Check that the saturation values are valid for all swcr"""
     wateroil = WaterOil(swcr=swcr)
     check_table(wateroil.table)
 
 
-@given(st.floats(min_value=0, max_value=1))
+@given(st.floats(min_value=0, max_value=1 - EPSILON))
 def test_wateroil_sorw(sorw):
     """Check that the saturation values are valid for all sorw"""
     wateroil = WaterOil(sorw=sorw)
     check_table(wateroil.table)
 
 
-@given(st.floats(min_value=0, max_value=1))
+@given(st.floats(min_value=0, max_value=1 - EPSILON))
 def test_wateroil_socr(socr):
     """Check that the saturation values are valid for all socr"""
     wateroil = WaterOil(socr=socr)


### PR DESCRIPTION
pytest-hypothesis has not been good at exploring the endpoints
of floating point intervals. This is fixed in version 6.49.7
of hypothesis, which provokes some failures in pyscal tests. This
commit relaxes the test intervals slightly, to avoid outright wrong
input to pyscal objects.