### PR TITLE
Fix tainted version in CI and deploy frequency documentation

### DIFF
--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -79,12 +79,14 @@ jobs:
           python -c "import matplotlib.font_manager; matplotlib.font_manager._rebuild()"
 
       - name: Build documentation
+        if: matrix.os == 'ubuntu-latest'
         run: |
+          export SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF//refs\/tags\//}
           python docs/make_plots.py
           python setup.py build_sphinx
 
       - name: Update GitHub pages
-        if: github.repository_owner == 'equinor' && github.ref == 'refs/heads/master' && matrix.python-version == '3.6'
+        if: github.event_name == 'release' && matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest'
         run: |
             cp -R ./build/sphinx/html ../html
 
@@ -113,6 +115,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pyscal_pypi_token }}
         run: |
+          export SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF//refs\/tags\//}
           python -m pip install --upgrade setuptools wheel twine
           python setup.py sdist bdist_wheel
           twine upload dist/*


### PR DESCRIPTION
- Closes #361 (now documentation is only deployed on releases, which also ensure users don't see unreleased content).
- Closes #358 (it becomes possible to deploy to PyPI again).
- Closes #306.

This PR uses the [same solution as in `webviz-subsurface-components`](https://github.com/equinor/webviz-subsurface-components/blob/c1f65d6daacc55af48f0a330fad400a1ce0e270b/.github/workflows/webviz-subsurface-components.yml#L149) (where some JavaScript files are built by the CI, but that should be considered as part of the same version). Documented here https://github.com/pypa/setuptools_scm#environment-variables.