### PR TITLE
Upload docs after upload to PyPI

### DIFF
--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -85,6 +85,17 @@ jobs:
           python docs/make_plots.py
           python setup.py build_sphinx
 
+      - name: Build python package and publish to pypi
+        if: github.event_name == 'release' && matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pyscal_pypi_token }}
+        run: |
+          export SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF//refs\/tags\//}
+          python -m pip install --upgrade setuptools wheel twine
+          python setup.py sdist bdist_wheel
+          twine upload dist/*
+
       - name: Update GitHub pages
         if: github.event_name == 'release' && matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest'
         run: |
@@ -108,14 +119,3 @@ jobs:
               git commit -m "Update Github Pages"
               git push "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
             fi
-
-      - name: Build python package and publish to pypi
-        if: github.event_name == 'release' && matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest'
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.pyscal_pypi_token }}
-        run: |
-          export SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF//refs\/tags\//}
-          python -m pip install --upgrade setuptools wheel twine
-          python setup.py sdist bdist_wheel
-          twine upload dist/*


### PR DESCRIPTION
Now that GitHub pages are uploaded on _release_, and since this step heavily changes the checked out folder/repository, we need to upload to PyPI first.