### PR TITLE
Don't override ci hypothesis settings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,13 @@ from hypothesis import HealthCheck, settings
 settings.register_profile(
     "ci", max_examples=250, deadline=None, suppress_health_check=[HealthCheck.too_slow]
 )
-settings.register_profile("slow", max_examples=50, deadline=1000)
+
+if settings().deadline is None:
+    # Check if the 'ci' profile above has been activated, then we don't want to
+    # override:
+    settings.register_profile("slow")
+else:
+    settings.register_profile("slow", max_examples=50, deadline=1000)
 
 
 @pytest.fixture


### PR DESCRIPTION
Solves deadline errors CI as the slow profile override the ci profile.