### PR TITLE
Resolve flakyness in linearity test

### DIFF
--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -999,7 +999,7 @@ class GasOil(object):
 
     def plotkrgkrog(
         self,
-        mpl_ax: None,
+        mpl_ax = None,
         color: str = "blue",
         alpha: float = 1.0,
         linewidth: int = 1,

--- a/pyscal/utils/testing.py
+++ b/pyscal/utils/testing.py
@@ -196,12 +196,12 @@ def check_linear_sections(wo_or_go: Union[WaterOil, GasOil]) -> None:
     left_lin_seg = wo_or_go.table[
         (wo_or_go.table[sat_col] >= left_start) & (wo_or_go.table[sat_col] <= left_end)
     ]
-    if len(right_lin_seg) > 4:
+    if len(right_lin_seg) > 5:
         for col in right_lin_cols:
-            # We avoid the first and last row in right_lin_seg, because
+            # We avoid the first and two lasts row in right_lin_seg, because
             # this does not always match the constant saturation segment
             # assumption in this linearity test:
-            assert right_lin_seg.iloc[1:-1][col].diff().std() < 1e-9
+            assert right_lin_seg.iloc[1:-2][col].diff().std() < 1e-9
     if len(left_lin_seg) > 4:
         for col in left_lin_cols:
             assert left_lin_seg.iloc[1:-1][col].diff().std() < 1e-9

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -203,10 +203,12 @@ def test_gasoil_krendmax(
     else:
         sgro = 0
     try:
+        assert 1 - sorg - swl - sgcr > 1 / SWINTEGERS, "No saturation range left"
         gasoil = GasOil(
             swl=swl, sgcr=sgcr, sorg=sorg, sgro=sgro, h=h, tag="", fast=fast
         )
     except AssertionError:
+        # We end here when hypothesis sets up impossible/non-interesting scenarios
         return
     krgend = min(krgend, krgmax)
     kroend = min(kroend, kromax)


### PR DESCRIPTION
In rare numerical corner cases, the linearity tests report a false positive as it gets a wrong assumption on which part of the saturation range has constant saturation step length. This patch relaxes the linearity test by always skipping the last two rows instead of only the last row.

In the false positives that spurred this change, the last saturation step in `right_lin_seg` is double the size of the other saturation steps. This is most likely a consequence of how the saturation points are chosen based on the floating point input, and constitutes the corner case.