### PR TITLE
Introduce separate MAX_EXPONENT parameters for kr and pc

### DIFF
--- a/pyscal/constants.py
+++ b/pyscal/constants.py
@@ -8,13 +8,17 @@
    comparisons/errors pop up.  You cannot have the h parameter less
    than this when generating relperm tables
 
- * ``MAX_EXPONENT``: Maximal number for exponents in relperm parametrizations.
+ * ``MAX_EXPONENT_KR``: Maximal number for exponents in relperm parameterizations.
    Used to avoid numerical instabilities. It could probably be much
    higher than the chosen number in most circumstances, but such high
    numbers should not be relevant for relative permeability
+
+ * ``MAX_EXPONENT_PC``: Maximal number for exponents in cap pressure parameterizations.
 """
 SWINTEGERS: int = 10000
 
 EPSILON: float = 1e-08
 
-MAX_EXPONENT: float = 100
+MAX_EXPONENT_KR: float = 100
+
+MAX_EXPONENT_PC: float = 10000

--- a/pyscal/gasoil.py
+++ b/pyscal/gasoil.py
@@ -8,7 +8,7 @@ from scipy.interpolate import PchipInterpolator
 
 import pyscal
 from pyscal.constants import EPSILON as epsilon
-from pyscal.constants import MAX_EXPONENT, SWINTEGERS
+from pyscal.constants import MAX_EXPONENT_KR, SWINTEGERS
 from pyscal.utils.relperm import crosspoint, estimate_diffjumppoint, truncate_zeroness
 from pyscal.utils.string import comment_formatter, df2str
 
@@ -456,7 +456,7 @@ class GasOil(object):
 
         krgmax is only relevant if krgendanchor is 'sorg'
         """
-        assert epsilon < ng < MAX_EXPONENT
+        assert epsilon < ng < MAX_EXPONENT_KR
         assert 0 < krgend <= 1.0
         if krgmax is not None:
             assert 0 < krgend <= krgmax <= 1.0
@@ -492,7 +492,7 @@ class GasOil(object):
         Returns:
             None (modifies internal class state)
         """
-        assert epsilon < nog < MAX_EXPONENT
+        assert epsilon < nog < MAX_EXPONENT_KR
         assert 0 < kroend <= 1.0
 
         self.table["KROG"] = kroend * self.table["SON"] ** nog
@@ -534,9 +534,9 @@ class GasOil(object):
         # Similar code in wateroil.add_LET_water, but readability
         # is better by having them separate
         # pylint: disable=duplicate-code
-        assert epsilon < l < MAX_EXPONENT
-        assert epsilon < e < MAX_EXPONENT
-        assert epsilon < t < MAX_EXPONENT
+        assert epsilon < l < MAX_EXPONENT_KR
+        assert epsilon < e < MAX_EXPONENT_KR
+        assert epsilon < t < MAX_EXPONENT_KR
         if krgmax:
             assert 0 < krgend <= krgmax <= 1.0
         else:
@@ -582,9 +582,9 @@ class GasOil(object):
             kromax: Value at sg=0 for sgro > 0
 
         """
-        assert epsilon < l < MAX_EXPONENT
-        assert epsilon < e < MAX_EXPONENT
-        assert epsilon < t < MAX_EXPONENT
+        assert epsilon < l < MAX_EXPONENT_KR
+        assert epsilon < e < MAX_EXPONENT_KR
+        assert epsilon < t < MAX_EXPONENT_KR
         assert 0 < kroend <= 1.0
 
         self.table["KROG"] = (

--- a/pyscal/utils/capillarypressure.py
+++ b/pyscal/utils/capillarypressure.py
@@ -2,7 +2,7 @@
 
 import math
 
-from pyscal.constants import MAX_EXPONENT
+from pyscal.constants import MAX_EXPONENT_PC
 
 
 def simple_J(
@@ -49,8 +49,8 @@ def simple_J(
         capillary pressure, same type as swnpc input argument.
     """  # noqa
     assert g >= 0
-    assert b < MAX_EXPONENT
-    assert b > -MAX_EXPONENT
+    assert b < MAX_EXPONENT_PC
+    assert b > -MAX_EXPONENT_PC
     assert 0.0 <= poro_ref <= 1.0
     assert perm_ref > 0.0
 

--- a/pyscal/wateroil.py
+++ b/pyscal/wateroil.py
@@ -9,7 +9,7 @@ from scipy.interpolate import PchipInterpolator, interp1d
 
 import pyscal
 from pyscal.constants import EPSILON as epsilon
-from pyscal.constants import MAX_EXPONENT, SWINTEGERS
+from pyscal.constants import MAX_EXPONENT_KR, MAX_EXPONENT_PC, SWINTEGERS
 from pyscal.utils.capillarypressure import simple_J
 from pyscal.utils.relperm import crosspoint, estimate_diffjumppoint, truncate_zeroness
 from pyscal.utils.string import comment_formatter, df2str
@@ -433,7 +433,7 @@ class WaterOil(object):
             krwend: value of krw at 1 - sorw.
             krwmax): maximal value at Sw=1. Default 1
         """
-        assert 10 * epsilon < nw < MAX_EXPONENT
+        assert 10 * epsilon < nw < MAX_EXPONENT_KR
         if krwmax:
             assert 0 < krwend <= krwmax <= 1.0
         else:
@@ -537,9 +537,9 @@ class WaterOil(object):
         # Similar code in gasoil.add_LET_gas, but readability is
         # better by having them separate.
         # pylint: disable=duplicate-code
-        assert epsilon < l < MAX_EXPONENT
-        assert epsilon < e < MAX_EXPONENT
-        assert epsilon < t < MAX_EXPONENT
+        assert epsilon < l < MAX_EXPONENT_KR
+        assert epsilon < e < MAX_EXPONENT_KR
+        assert epsilon < t < MAX_EXPONENT_KR
         if krwmax:
             assert 0 < krwend <= krwmax <= 1.0
         else:
@@ -581,9 +581,9 @@ class WaterOil(object):
         Returns:
             None (modifies object)
         """
-        assert epsilon < l < MAX_EXPONENT
-        assert epsilon < e < MAX_EXPONENT
-        assert epsilon < t < MAX_EXPONENT
+        assert epsilon < l < MAX_EXPONENT_KR
+        assert epsilon < e < MAX_EXPONENT_KR
+        assert epsilon < t < MAX_EXPONENT_KR
         assert 0 < kroend <= 1.0
 
         self.table["KROW"] = (
@@ -615,7 +615,7 @@ class WaterOil(object):
         Returns:
             None (modifies object)
         """
-        assert epsilon < now < MAX_EXPONENT
+        assert epsilon < now < MAX_EXPONENT_KR
         assert 0 < kroend <= 1.0
 
         self.table["KROW"] = kroend * self.table["SON"] ** now
@@ -670,8 +670,8 @@ class WaterOil(object):
             None. Modifies pc column in self.table, using bar as pressure unit.
         """  # noqa
         assert g >= 0
-        assert b < MAX_EXPONENT
-        assert b > -MAX_EXPONENT
+        assert b < MAX_EXPONENT_PC
+        assert b > -MAX_EXPONENT_PC
         assert 0.0 <= poro_ref <= 1.0
         assert perm_ref > 0.0
 
@@ -743,8 +743,8 @@ class WaterOil(object):
             None. Modifies pc column in self.table, using bar as pressure unit.
         """  # noqa
         assert g >= 0
-        assert b < MAX_EXPONENT
-        assert b > -MAX_EXPONENT
+        assert b < MAX_EXPONENT_PC
+        assert b > -MAX_EXPONENT_PC
         assert 0.0 <= poro_ref <= 1.0
         assert perm_ref > 0.0
 
@@ -798,8 +798,8 @@ class WaterOil(object):
         Returns:
             None. Modifies pc column in self.table, using bar as pressure unit.
         """  # noqa
-        assert epsilon < abs(a) < MAX_EXPONENT
-        assert epsilon < abs(b) < MAX_EXPONENT
+        assert epsilon < abs(a) < MAX_EXPONENT_PC
+        assert epsilon < abs(b) < MAX_EXPONENT_PC
         assert epsilon < poro <= 1.0
         assert epsilon < perm
         assert isinstance(sigma_costau, (int, float))
@@ -928,12 +928,12 @@ class WaterOil(object):
         Note that Pc where Sw > 1 - sorw will appear linear because
         there are no saturation points in that interval.
         """  # noqa
-        assert epsilon < Lp < MAX_EXPONENT
-        assert epsilon < Ep < MAX_EXPONENT
-        assert epsilon < Tp < MAX_EXPONENT
-        assert epsilon < Lt < MAX_EXPONENT
-        assert epsilon < Et < MAX_EXPONENT
-        assert epsilon < Tt < MAX_EXPONENT
+        assert epsilon < Lp < MAX_EXPONENT_PC
+        assert epsilon < Ep < MAX_EXPONENT_PC
+        assert epsilon < Tp < MAX_EXPONENT_PC
+        assert epsilon < Lt < MAX_EXPONENT_PC
+        assert epsilon < Et < MAX_EXPONENT_PC
+        assert epsilon < Tt < MAX_EXPONENT_PC
         assert Pct <= Pcmax
 
         # The "forced part"
@@ -977,12 +977,12 @@ class WaterOil(object):
 
         Docs: https://wiki.equinor.com/wiki/index.php/Res:The_LET_correlation_for_capillary_pressure
         """  # noqa
-        assert epsilon < Ls < MAX_EXPONENT
-        assert epsilon < Es < MAX_EXPONENT
-        assert epsilon < Ts < MAX_EXPONENT
-        assert epsilon < Lf < MAX_EXPONENT
-        assert epsilon < Ef < MAX_EXPONENT
-        assert epsilon < Tf < MAX_EXPONENT
+        assert epsilon < Ls < MAX_EXPONENT_PC
+        assert epsilon < Es < MAX_EXPONENT_PC
+        assert epsilon < Ts < MAX_EXPONENT_PC
+        assert epsilon < Lf < MAX_EXPONENT_PC
+        assert epsilon < Ef < MAX_EXPONENT_PC
+        assert epsilon < Tf < MAX_EXPONENT_PC
         assert Pcmin <= Pct <= Pcmax
 
         # Normalized water saturation including sorw

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -11,7 +11,7 @@ import pytest
 from hypothesis import given
 
 from pyscal import GasOil
-from pyscal.constants import MAX_EXPONENT, SWINTEGERS
+from pyscal.constants import MAX_EXPONENT_KR, SWINTEGERS
 from pyscal.utils.relperm import truncate_zeroness
 from pyscal.utils.testing import (
     check_linear_sections,
@@ -403,8 +403,8 @@ def test_kroend():
 
 
 @given(
-    st.floats(min_value=1e-4, max_value=MAX_EXPONENT),  # ng
-    st.floats(min_value=1e-4, max_value=MAX_EXPONENT),  # nog
+    st.floats(min_value=1e-4, max_value=MAX_EXPONENT_KR),  # ng
+    st.floats(min_value=1e-4, max_value=MAX_EXPONENT_KR),  # nog
 )
 def test_gasoil_corey1(ng, nog):
     """Test the Corey formulation for gasoil"""

--- a/tests/test_wateroil_pc.py
+++ b/tests/test_wateroil_pc.py
@@ -6,7 +6,7 @@ import pytest
 from hypothesis import given
 
 from pyscal import WaterOil
-from pyscal.constants import MAX_EXPONENT
+from pyscal.constants import MAX_EXPONENT_PC
 from pyscal.utils.testing import check_table, float_df_checker, sat_table_str_ok
 
 
@@ -86,7 +86,7 @@ def test_simple_j_petro():
 
 @given(
     st.floats(min_value=0.001, max_value=1000000),
-    st.floats(min_value=-0.9 * MAX_EXPONENT, max_value=-0.001),
+    st.floats(min_value=-0.9 * MAX_EXPONENT_PC, max_value=-0.001),
     st.floats(min_value=0.01, max_value=0.5),
     st.floats(min_value=0.001, max_value=10),
     st.floats(min_value=0.01, max_value=1000000),
@@ -142,7 +142,7 @@ def test_normalized_j(caplog):
     st.floats(min_value=0, max_value=0.1),  # swirr
     st.floats(min_value=0.01, max_value=0.1),  # swl - swirr
     st.floats(min_value=0.01, max_value=5),  # a
-    st.floats(min_value=-0.9 * MAX_EXPONENT, max_value=-0.01),  # b
+    st.floats(min_value=-0.9 * MAX_EXPONENT_PC, max_value=-0.01),  # b
     st.floats(min_value=-1, max_value=1.5),  # poro
     st.floats(min_value=0.0001, max_value=1000000000),  # perm
     st.floats(min_value=0, max_value=100000),  # sigma_costau


### PR DESCRIPTION
Introducing separate MAX_EXPONENT parameters for relative permeability and capillary pressure to allow for use of higher LET parameters when creating Pc curves. I have followed the contributing guidelines but I haven't created updated Sphinx docs.