### PR TITLE
Pin numpy < 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LONG_DESCRIPTION = (Path(__file__).parent / "README.md").read_text()
 
 REQUIREMENTS = [
     "matplotlib",
-    "numpy",
+    "numpy<2",
     "openpyxl",
     "pandas",
     "scipy",


### PR DESCRIPTION
numpy 2.0 is coming in December 2023 or January 2024 and its developers have recommended pinning it to test against release candidates. This pin will be enforced elsewhere within Komodo.

Closes #410 