### PR TITLE
Fix workflow for publish to pypi

### DIFF
--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -106,7 +106,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.pyscal_pypi_token }}
         run: |
           export SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF//refs\/tags\//}
-          pip install build
+          pip install -U build twine  # and maybe setuptools? not sure
           python -m build
           twine upload dist/*
 

--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -106,8 +106,8 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.pyscal_pypi_token }}
         run: |
           export SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF//refs\/tags\//}
-          python -m pip install --upgrade setuptools wheel twine
-          python setup.py sdist bdist_wheel
+          pip install build
+          python -m build
           twine upload dist/*
 
       - name: Update GitHub pages


### PR DESCRIPTION
Missed this when migrating from setup.py to pyproject.toml