### PR TITLE
Unpin urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "openpyxl",
     "pandas",
     "scipy",
-    "urllib3<2",
     "xlrd",
 ]
 


### PR DESCRIPTION
Prefer to have komodo restrict the necessary urllib3 version for specific rhel versions.