### PR TITLE
Modification to add_LET_pc_pd 

### DIFF
--- a/src/pyscal/wateroil.py
+++ b/src/pyscal/wateroil.py
@@ -962,7 +962,7 @@ class WaterOil:
         )
 
         # The gradual rise part:
-        self.table["Ftpcow"] = (1-Ftp)*Pct*self.table["SWNPC"] ** Lt / (
+        self.table["Ftpcow"] = (1-Ftp)*self.table["SWNPC"] ** Lt / (
             self.table["SWNPC"] ** Lt + Et * (1 - self.table["SWNPC"]) ** Tt
         )
         

--- a/src/pyscal/wateroil.py
+++ b/src/pyscal/wateroil.py
@@ -929,11 +929,14 @@ class WaterOil:
         Tt: float,
         Pcmax: float,
         Pct: float,
+        Ftp: Optional[bool] = False,
     ) -> None:
         """Add a primary drainage LET capillary pressure curve.
 
         Docs: https://wiki.equinor.com/wiki/index.php/Res:The_LET_correlation_for_capillary_pressure
 
+        It includes a welldefined threshold pressure Pct if required, and Ftp is a flag that is either True or False defining whether a
+        threshold pressure should be used or not. 
         Note that Pc where Sw > 1 - sorw will appear linear because
         there are no saturation points in that interval.
         """
@@ -945,16 +948,24 @@ class WaterOil:
         assert epsilon < Tt < MAX_EXPONENT_PC
         assert Pct <= Pcmax
 
+        # swnpc is a normalized saturation, but normalized with
+        # respect to swirr, not to swl (the swirr here is sometimes
+        # called 'swirra' - asymptotic swirr)
+        # LET Pc is provides and finite Pc value, thus swirr does not fit into the concept
+        # swnpc is generated upon object initialization, but overwritten
+        # here and normalized with respect to swl
+        self.table["SWNPC"] = (self.table["SW"] - self.swl) / (1 - self.swl)
+ 
         # The "forced part"
         self.table["Ffpcow"] = (1 - self.table["SWNPC"]) ** Lp / (
             (1 - self.table["SWNPC"]) ** Lp + Ep * self.table["SWNPC"] ** Tp
         )
 
         # The gradual rise part:
-        self.table["Ftpcow"] = self.table["SWNPC"] ** Lt / (
+        self.table["Ftpcow"] = (1-Ftp)*Pct*self.table["SWNPC"] ** Lt / (
             self.table["SWNPC"] ** Lt + Et * (1 - self.table["SWNPC"]) ** Tt
         )
-
+        
         # Putting it together:
         self.table["PC"] = (
             (Pcmax - Pct) * self.table["Ffpcow"] - Pct * self.table["Ftpcow"] + Pct
@@ -966,7 +977,7 @@ class WaterOil:
             "-- LET correlation for primary drainage Pc;\n"
             f"-- Lp={Lp:g}, Ep={Ep:g}, Tp={Tp:g}, "
             f"Lt={Lt:g}, Et={Et:g}, Tt={Tt:g}, "
-            f"Pcmax={Pcmax:g}, Pct={Pct:g}\n"
+            f"Pcmax={Pcmax:g}, Pct={Pct:g}, Ftp={Ftp}\n"
         )
 
     def add_LET_pc_imb(

--- a/tests/test_wateroil_pc.py
+++ b/tests/test_wateroil_pc.py
@@ -174,6 +174,11 @@ def test_let_pc_pd():
     assert np.isclose(wateroil.table["PC"].min(), 0)
     # (everything is linear)
 
+    #Test for added threshold in the function
+    wateroil.add_LET_pc_pd(Lp=1, Ep=1, Tp=1, Lt=1, Et=1, Tt=1, Pcmax=10, Pct=5, Ftp=True)
+    assert np.isclose(wateroil.table["PC"].max(), 10)
+    assert np.isclose(wateroil.table["PC"].min(), 5)
+
     wateroil.add_LET_pc_pd(Lp=10, Ep=10, Tp=10, Lt=10, Et=10, Tt=10, Pcmax=10, Pct=5)
     assert np.isclose(wateroil.table["PC"].max(), 10)
     assert np.isclose(wateroil.table["PC"].min(), 0)


### PR DESCRIPTION
A flag for including a capillary pressure threshold (Ftp) is added to the add_LET_pc_pd function. 
In old version, setting swirr=swl provides correct Pc LET curve, otherwise it gives wrong Pc LET curve.
Therefore, swnpc is re-normalized with respect to swl, not to swirr as it is initially. This is similar procedure to normalization of SWNPC in the add_skjaeveland_pc function.
LET Pc is provides and finite Pc value, thus swirr does not fit into the concept

A test for the Pc threshold is added to test_wateroil_pc.py

