### PR TITLE
Fix matplotlib argument typing

### DIFF
--- a/src/pyscal/gasoil.py
+++ b/src/pyscal/gasoil.py
@@ -1035,7 +1035,7 @@ class GasOil:
             useax = mpl_ax
         if logyscale:
             useax.set_yscale("log")
-            useax.set_ylim([1e-8, 1])
+            useax.set_ylim((1e-8, 1))
         self.table.plot(
             ax=useax,
             x="SG",

--- a/src/pyscal/gaswater.py
+++ b/src/pyscal/gaswater.py
@@ -332,7 +332,7 @@ class GasWater:
             useax = mpl_ax
         if logyscale:
             useax.set_yscale("log")
-            useax.set_ylim([1e-8, 1])
+            useax.set_ylim((1e-8, 1))
         self.wateroil.table.plot(
             ax=useax,
             x="SW",

--- a/src/pyscal/wateroil.py
+++ b/src/pyscal/wateroil.py
@@ -1355,7 +1355,7 @@ class WaterOil:
             useax = mpl_ax
         if logyscale:
             useax.set_yscale("log")
-            useax.set_ylim([1e-6, 100])
+            useax.set_ylim((1e-6, 100))
         self.table.plot(
             ax=useax,
             x="SW",
@@ -1397,7 +1397,7 @@ class WaterOil:
             useax = mpl_ax
         if logyscale:
             useax.set_yscale("log")
-            useax.set_ylim([1e-8, 1])
+            useax.set_ylim((1e-8, 1))
         self.table.plot(
             ax=useax,
             x="SW",


### PR DESCRIPTION
matplotlib updating its typing and indicated that the method arguments changed in this commit should not receive lists, but tuples.