### PR TITLE
Pin sphinx-argparse to < 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ tests = [
 docs = [
     "autoapi",
     "sphinx",
-    "sphinx-argparse",
+    "sphinx-argparse<0.5.0",
     "sphinx-autodoc-typehints",
     "sphinx_rtd_theme",
 ]


### PR DESCRIPTION
Pin sphinx-argparse to 0.4.0 due to this issue https://github.com/sphinx-doc/sphinx-argparse/issues/56

