### PR TITLE
Avoid non-unique saturation

### DIFF
--- a/src/pyscal/gasoil.py
+++ b/src/pyscal/gasoil.py
@@ -153,7 +153,7 @@ class GasOil:
         )
         sg_list.sort()
         self.table = pd.DataFrame(sg_list, columns=["SG"])
-        self.table["sgint"] = list(map(round, self.table["SG"] * SWINTEGERS))
+        self.table["sgint"] = list(map(round, self.table["SG"] * SWINTEGERS * 10))
         self.table = self.table.drop_duplicates("sgint")
 
         # Now sg=1-sorg-swl might be accidentally dropped, so make sure we

--- a/src/pyscal/wateroil.py
+++ b/src/pyscal/wateroil.py
@@ -162,7 +162,7 @@ class WaterOil:
 
         # Ensure that we do not have sw values that are too close
         # to each other, determined rougly by the distance 1/10000
-        self.table["swint"] = list(map(round, self.table["SW"] * SWINTEGERS))
+        self.table["swint"] = list(map(round, self.table["SW"] * SWINTEGERS * 10))
         self.table = self.table.drop_duplicates("swint")
 
         # Now, sw=1-sorw might be accidentaly dropped, so make sure we

--- a/src/pyscal/wateroilgas.py
+++ b/src/pyscal/wateroilgas.py
@@ -164,7 +164,7 @@ class WaterOilGas:
             .bfill()
             .reset_index()
         )
-        sof3table["soint"] = list(map(round, sof3table["SO"] * SWINTEGERS))
+        sof3table["soint"] = list(map(round, sof3table["SO"] * SWINTEGERS * 10))
         sof3table = sof3table.drop_duplicates("soint")
 
         # The 'so' column has been calculated from floating point numbers


### PR DESCRIPTION
Avoid non-unique saturation by increasing the s[w/g/o]int resolution by factor 10. 

Close #444 

