### PR TITLE
Match SWINTEGERS and saturation print format

### DIFF
--- a/src/pyscal/constants.py
+++ b/src/pyscal/constants.py
@@ -16,7 +16,7 @@
 * ``MAX_EXPONENT_PC``: Maximal number for exponents in cap pressure parameterizations.
 """
 
-SWINTEGERS: int = 10000
+SWINTEGERS: int = 100000
 
 EPSILON: float = 1e-08
 

--- a/src/pyscal/utils/relperm.py
+++ b/src/pyscal/utils/relperm.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def truncate_zeroness(
-    value: float, zeronesslimit: float = 1 / SWINTEGERS, name: str = "", log=True
+    value: float, zeronesslimit: float = 10 / SWINTEGERS, name: str = "", log=True
 ) -> float:
     """Check a value for closeness to zero, and return as zero if below
     a given limit, if not return the value"""

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -75,7 +75,7 @@ def test_gasoil_init():
 
 def test_conserve_sgcr(mocker):
     """sgcr in the table can be hard to conserve"""
-    low_sgcrvalue = 0.00001  # 1/10 of 1/SWINTEGERS
+    low_sgcrvalue = 1 / SWINTEGERS / 10
     # Verify the default behaviour of truncation:
     assert truncate_zeroness(low_sgcrvalue) == 0
     mocker.patch(

--- a/tests/test_gaswater.py
+++ b/tests/test_gaswater.py
@@ -22,7 +22,7 @@ from pyscal.utils.testing import (
 def check_endpoints(gaswater, krwend, krwmax, krgend):
     """Check that the code produces correct endpoints for
     parametrizations, on discrete cases"""
-    swtol = 1 / SWINTEGERS
+    swtol = 10 / SWINTEGERS
 
     # Check endpoints for gas curve:
     # krg at swl should be krgend:

--- a/tests/test_slgof.py
+++ b/tests/test_slgof.py
@@ -125,7 +125,7 @@ def test_numerical_problems(swl, sorg, sgcr):
     st.floats(min_value=0.0, max_value=0.3),
     st.floats(min_value=0.0, max_value=0.3),
     st.floats(min_value=0.0, max_value=0.3),
-    st.floats(min_value=1.0 / float(1000 * SWINTEGERS), max_value=0.5),
+    st.floats(min_value=1.0 / float(100 * SWINTEGERS), max_value=0.5),
 )
 def test_slgof_hypo(swl, sorg, sgcr, h):
     """Shotgun-testing of slgof"""
@@ -148,7 +148,7 @@ def test_slgof_hypo(swl, sorg, sgcr, h):
 @given(
     st.floats(min_value=0.0, max_value=0.3),
     st.floats(min_value=0.0, max_value=0.3),
-    st.floats(min_value=1.0 / float(1000 * SWINTEGERS), max_value=0.5),
+    st.floats(min_value=1.0 / float(100 * SWINTEGERS), max_value=0.5),
 )
 def test_slgof_sl_mismatch(swl, sorg, h):
     """Test numerical robustness on slgof table creation."""


### PR DESCRIPTION
    The documentation for SWINTEGERS did not match the accuracy of printed
    floating numbers, and this lead to a rare possibility for test failures,
    exemplified by test_slgof.py::test_slgof_hypo where it was possible to
    end up with two saturation points being printed identically.
    
    The usage of SWINTEGERS in test code has been tuned accordingly.
    
    Co-authored by: Alif Be <11570927+alifbe@users.noreply.github.com>
