### PR TITLE
Fix h_min after unintended change

### DIFF
--- a/src/pyscal/gasoil.py
+++ b/src/pyscal/gasoil.py
@@ -89,7 +89,7 @@ class GasOil:
 
         assert isinstance(krgendanchor, str), "krgendanchor must be a string"
 
-        h_min = 1.0 / float(SWINTEGERS)
+        h_min = 10.0 / float(SWINTEGERS)
         if h < h_min:
             logger.warning(
                 "Requested saturation step length (%g) too small, reset to %g", h, h_min

--- a/src/pyscal/wateroil.py
+++ b/src/pyscal/wateroil.py
@@ -106,7 +106,7 @@ class WaterOil:
 
         self.swcomment: str = ""
 
-        h_min = 1.0 / float(SWINTEGERS)
+        h_min = 10.0 / float(SWINTEGERS)
         if h < h_min:
             logger.warning(
                 "Requested saturation step length (%g) too small, reset to %g", h, h_min

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -70,7 +70,7 @@ def test_gasoil_init():
     # Test too small h:
     gasoil = GasOil(swl=0.1, h=0.00000000000000000001)
     # (a warning is printed that h is truncated)
-    assert gasoil.h == 1 / SWINTEGERS
+    assert gasoil.h == 10 / SWINTEGERS
 
 
 def test_conserve_sgcr(mocker):

--- a/tests/test_slgof.py
+++ b/tests/test_slgof.py
@@ -125,7 +125,7 @@ def test_numerical_problems(swl, sorg, sgcr):
     st.floats(min_value=0.0, max_value=0.3),
     st.floats(min_value=0.0, max_value=0.3),
     st.floats(min_value=0.0, max_value=0.3),
-    st.floats(min_value=1.0 / float(100 * SWINTEGERS), max_value=0.5),
+    st.floats(min_value=1.0 / SWINTEGERS, max_value=0.5),
 )
 def test_slgof_hypo(swl, sorg, sgcr, h):
     """Shotgun-testing of slgof"""


### PR DESCRIPTION
SWINTEGERS was changed in the referred commit, and other critical usage of that constant has to be adjusted accordingly.

There are still other places where SWINTEGERS are used, but as long as tests pass they should be fine.

Also adjust the lower limit for h in test_slgof_hypo. If h can become much lower than h_min, hypothesis shrinking in case of errors becomes very slow.