### PR TITLE
Relax requirement for interpolation in tests

### DIFF
--- a/tests/test_utils_interpolation.py
+++ b/tests/test_utils_interpolation.py
@@ -325,7 +325,7 @@ def test_interpolate_wo(
     # that is the std.dev of the distances is low:
     ip_dist_std = np.std(np.diff(dists[1:]))  # This number depends on 'h' and 't' range
     # (avoiding the first which reproduces wo_low
-    if ip_dist_std > 1.1:  # Found by trial and error
+    if ip_dist_std > 1.2:  # Found by trial and error
         print(f"ip_dist_std: {ip_dist_std}")
         print(dists)
 


### PR DESCRIPTION
This is tuning of commit 4c66136881ab0da0a96dcf50a9a2b472f8ff1ab8

@reproduce_failure('6.114.1', b'AXicY2BgOGDAgAUc8L/eJVux8DqIKYAQFUBXx0gME9kEBXwmAABmjwjE') triggers a failure (ip_dist_std =  ~1.13) which the accompanying plot reveals is perfectly fine.