### PR TITLE
Krowgend add to factory water_oil_gas

### DIFF
--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -658,12 +658,34 @@ def test_factory_wateroilgas():
     assert wateroil.gasoil is None
 
 
-def test_factory_wateroilgas_deprecated_krowgend():
-    """Using long-time deprecated krowend and krogend will fail"""
-    with pytest.raises(ValueError):
-        create_water_oil_gas(
-            {"nw": 2, "now": 3, "ng": 1, "nog": 2.5, "krowend": 0.6, "krogend": 0.7}
-        )
+def test_factory_wateroilgas_krowgend():
+    """Test convert krowend and krogend to kroend and put into
+    create_water_oil and create_oil_gas, respectively"""
+
+    wog = create_water_oil_gas(
+        {
+            "nw": 2,
+            "now": 3,
+            "ng": 1,
+            "nog": 2.5,
+            "krowend": 0.6,
+            "krogend": 0.7,
+            "kroend": 0.5,
+        }
+    )
+    swof = wog.SWOF()
+    sgof = wog.SGOF()
+    sat_table_str_ok(swof)  # sgof code works for swof also currently
+    sat_table_str_ok(sgof)
+    assert "Corey krg" in sgof
+    assert "Corey krog" in sgof
+    assert "kroend=0.7" in sgof
+    assert "Corey krw" in swof
+    assert "Corey krow" in swof
+    assert "kroend=0.6" in swof
+
+    check_table(wog.gasoil.table)
+    check_table(wog.wateroil.table)
 
 
 def test_factory_wateroilgas_wo():
@@ -1069,6 +1091,9 @@ def test_check_deprecated_krowgend():
     to the oil curve parametrization for WaterOil and GasOil. From
     pyscal 0.6.0, krogend and krowend are merged to kroend.
     After pyscal 0.8 presence of krogend and krowend is a ValueError
+    After pyscal 0.14 presence krogend and krowend is accepted as
+    parameters for create_wateroilgas, but is still ValueError for
+    create_water_oil and create_gas_oil is a
     """
     with pytest.raises(ValueError):
         create_water_oil({"swl": 0.1, "nw": 2, "now": 2, "krowend": 0.4})


### PR DESCRIPTION
This pull request proposes a solution for issue #455.

**Issue** The original issue reported that the current implementation of the WaterOilGas object did not allow for separate values of KROEND for water/oil and oil/gas systems. This is desirable in cases such as gas condensate systems and when oil moves into a gas cap. The issue includes examples and a figure to illustrate the problem.

**Proposed solution** The proposed solution is to accept both KROGEND (oil/gas) and KROWEND (water/oil) for the WaterOilGas object, then convert these into two separate KROEND and apply them to the respective WaterOil and OilGas objects. Thus, it does not affect anchoring of KROEND to critical and residual saturations. KROEND for WaterOil anchor to SWL, while KROEND GasOil anchor to SGCR=SGRO. 
A test has been added to ensure this feature works.

**Documentation** No changes to the documentation have been made at this time. We will await approval of the proposed solution before updating the documentation.

