### PR TITLE
Drop python 3.8 and add 3.12

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.11'
+      PYTHON: '3.12'
 
     steps:
     - uses: actions/checkout@main
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
 
     - name: Install pyscal and test dependencies
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   # Default python version to be use to create docs
-  DEFAULT_PYTHON_VERSION: "3.11"
+  DEFAULT_PYTHON_VERSION: "3.12"
 
 jobs:
   pyscal:
@@ -25,17 +25,17 @@ jobs:
       matrix:
         include:
           - os: "ubuntu-latest"
-            python-version: "3.8"
-          - os: "ubuntu-latest"
             python-version: "3.9"
           - os: "ubuntu-latest"
             python-version: "3.10"
           - os: "ubuntu-latest"
             python-version: "3.11"
+          - os: "ubuntu-latest"
+            python-version: "3.12"
           - os: "macos-latest"
-            python-version: "3.11"
+            python-version: "3.12"
           - os: "windows-latest"
-            python-version: "3.11"
+            python-version: "3.12"
 
     steps:
       - name: Checkout commit locally
@@ -92,7 +92,6 @@ jobs:
       - name: Build documentation
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == env.DEFAULT_PYTHON_VERSION }}
         run: |
-          export SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF//refs\/tags\//}
           python docs/make_plots.py
           sphinx-build -b html docs ./build/sphinx/html
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://github.com/equinor/pyscal/actions/workflows/pyscal.yml/badge.svg)](https://github.com/equinor/pyscal/actions?query=workflow%3Apyscal)
 [![codecov](https://codecov.io/gh/equinor/pyscal/branch/master/graph/badge.svg)](https://codecov.io/gh/equinor/pyscal)
-[![Python 3.8-3.12](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20-blue.svg)](https://www.python.org)
+[![Python 3.9-3.12](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20-blue.svg)](https://www.python.org)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![PyPI version](https://badge.fury.io/py/pyscal.svg)](https://badge.fury.io/py/pyscal)
 [![Downloads](https://pepy.tech/badge/pyscal)](https://pepy.tech/project/pyscal)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://github.com/equinor/pyscal/actions/workflows/pyscal.yml/badge.svg)](https://github.com/equinor/pyscal/actions?query=workflow%3Apyscal)
 [![codecov](https://codecov.io/gh/equinor/pyscal/branch/master/graph/badge.svg)](https://codecov.io/gh/equinor/pyscal)
-[![Python 3.8-3.11](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10|%203.11-blue.svg)](https://www.python.org)
+[![Python 3.8-3.12](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20-blue.svg)](https://www.python.org)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![PyPI version](https://badge.fury.io/py/pyscal.svg)](https://badge.fury.io/py/pyscal)
 [![Downloads](https://pepy.tech/badge/pyscal)](https://pepy.tech/project/pyscal)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,15 +16,20 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import datetime
 
-import pkg_resources
+import pyscal
 
 # -- Project information -----------------------------------------------------
 
 project = "pyscal"
 author = "Håvard Berland"
 copyright = f"Equinor 2019-{datetime.date.today().year}"
+try:
+    release = pyscal.__version__
+except AttributeError:
+    import subprocess
 
-release = pkg_resources.get_distribution("pyscal").version
+    release = str(subprocess.check_output(["git", "describe", "--always"]))
+
 version = release
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Natural Language :: English",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
 ]


### PR DESCRIPTION
Closes #474 
- Drop support for python 3.8
- Add support for python 3.12
- Use python 3.12 as default in Github action