### PR TITLE
Fix related to mypy 1.16

### DIFF
--- a/src/pyscal/utils/monotonicity.py
+++ b/src/pyscal/utils/monotonicity.py
@@ -164,18 +164,17 @@ def clip_accumulate(
     Returns:
         np.array, copy of original.
     """
-    if isinstance(series, (list, np.ndarray)):
-        series = pd.Series(series, dtype="float64")
+    series = np.array(series)
     if monotonicity["sign"] > 0:
         series = np.maximum.accumulate(series)
     else:
         series = np.minimum.accumulate(series)
     if "lower" in monotonicity and "upper" in monotonicity:
-        series = series.clip(lower=monotonicity["lower"], upper=monotonicity["upper"])
+        series = series.clip(min=monotonicity["lower"], max=monotonicity["upper"])
     elif "lower" in monotonicity:
-        series = series.clip(lower=monotonicity["lower"])
+        series = series.clip(min=monotonicity["lower"])
     elif "upper" in monotonicity:
-        series = series.clip(upper=monotonicity["upper"])
+        series = series.clip(max=monotonicity["upper"])
     return series
 
 


### PR DESCRIPTION
mypy 1.16 found issue with ambiguity of series.

Mypy figured that series will be of type numpy.ndarray, but the `.clip` signature call for numpy.ndarray is different compare to pandas.series `.clip` 