### PR TITLE
Fixup missing ecl2df -> res2df api changes

### DIFF
--- a/tests/test_pyscallist.py
+++ b/tests/test_pyscallist.py
@@ -168,7 +168,7 @@ def test_df():
             .dropna()
             .reset_index(drop=True)
         )
-        ecl_inc = res2df.satfunc.df2ecl(base_df_swof)
+        ecl_inc = res2df.satfunc.df2res(base_df_swof)
         dframe_from_inc = res2df.satfunc.df(ecl_inc)
         pd.testing.assert_frame_equal(base_df_swof, dframe_from_inc)
 
@@ -180,7 +180,7 @@ def test_df():
             .dropna()
             .reset_index(drop=True)
         )
-        ecl_inc = res2df.satfunc.df2ecl(base_df_sgof)
+        ecl_inc = res2df.satfunc.df2res(base_df_sgof)
         dframe_from_inc = res2df.satfunc.df(ecl_inc)
         pd.testing.assert_frame_equal(base_df_sgof, dframe_from_inc, check_like=True)
 


### PR DESCRIPTION
Error not catched since res2df is not installed in test workflow, added in https://github.com/equinor/pyscal/pull/482
Tested manually to work.