### PR TITLE
Redo monotonicity enforcement code

### DIFF
--- a/src/pyscal/utils/monotonicity.py
+++ b/src/pyscal/utils/monotonicity.py
@@ -1,6 +1,7 @@
-"""Monotonocity support functions for pyscal"""
+"""Monotonicity support functions for pyscal"""
 
 import logging
+from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal
 from typing import TypedDict
 
 import numpy as np
@@ -30,6 +31,40 @@ class MonotonicitySpec(TypedDict, total=False):
     allowzero: bool
     """If True, consecutive zeros will be allowes in an otherwise strictly
     monotonic column. Optional parameter."""
+
+
+def _quantize_to_fixed_point_int(
+    value: float, digits: int, rounding: str | None = None
+) -> int:
+    """Convert a IEEE754 floating point to an integer representation
+    for a specified accuracy.
+
+    Examples: f(0.01, 2) becomes 1, f(1.00, 2) becomes 100.
+
+    Decimal objects are used to guarantee that we are
+    snapping the floating points to the same values as we want
+    to see in the output, avoiding IEEE754 fallacies.
+
+    When enforcing monotonicity, rounding should be ceiling
+    for decreasing sequences, and floor for increasing sequences.
+    """
+    accuracy = Decimal(1).scaleb(-digits)
+    dec = Decimal(str(value)).quantize(accuracy, rounding=rounding)
+    return int(dec * 10**digits)
+
+
+def _format_fixed_point_int(fixed_point_int: int, digits: int) -> str:
+    """Convert integers that represent floating point number
+    to strings. Numbers will be zero-padded with to the
+    specified number of digits.
+
+    Examples:
+    f(100, 2) becomes "1.00" and f(1, 2) becomes "0.01"
+    """
+    scale = 10**digits
+    sign = "-" if fixed_point_int < 0 else ""
+    abs_quant_int = -fixed_point_int if fixed_point_int < 0 else fixed_point_int
+    return f"{sign}{abs_quant_int // scale}.{abs_quant_int % scale:0{digits}d}"
 
 
 def modify_dframe_monotonicity(
@@ -68,6 +103,9 @@ def modify_dframe_monotonicity(
         dframe: Data to modify.
         monotonicity: Keys are column names
         digits: Number of digits to ensure monotonicity for.
+
+    Returns a dataframe where monotonicity enforced columns have
+    a string datatype.
     """
     validate_monotonicity_arg(monotonicity, dframe.columns.to_list())
 
@@ -85,6 +123,8 @@ def modify_dframe_monotonicity(
         if dframe[col].dtype != np.float64:
             dframe[col] = dframe[col].astype(float)
 
+        assert "sign" in spec
+
         # Bail on clearly erroneous data:
         check_almost_monotone(dframe[col], digits, spec["sign"])
 
@@ -92,55 +132,54 @@ def modify_dframe_monotonicity(
 
     # Modify data for monotonicity:
     for col, spec in monotonicity.items():
-        accuracy = 1.0 / 10.0**digits - epsilon
-
         if "allowzero" in spec:
-            # Treat zero as an exception for strict monotonicity:
+            # Treat all-zero values as an exception for strict monotonicity:
             max_value = dframe[col].abs().max()
-            if max_value < accuracy and spec["allowzero"]:
+            if max_value < 1.0 / 10.0**digits - epsilon and spec["allowzero"]:
                 continue
 
-        constants = rows_to_be_fixed(dframe[col], spec, digits)
-        iterations = 0
-        sign = spec["sign"]
-        while constants.any():
-            iterations += 1
+        # Default rounding in Python is ROUND_HALF_EVEN, or "Bankers rounding".
+        # That rounding scheme is designed for summing numbers, not for
+        # strictly monotone sequences where it is safer to either always round
+        # up or down consistently
+        rounding: str = ROUND_FLOOR if spec["sign"] == 1 else ROUND_CEILING
 
-            assert iterations <= 2 * len(dframe[col]), (
-                "Too many iterations for monotonicity fix"
-            )
+        lower_fixed_int = upper_fixed_int = None
+        for boundary in ("lower", "upper"):
+            if spec.get(boundary) is not None:
+                boundary_value = spec.get(boundary)
+                assert isinstance(boundary_value, int | float)
+                if boundary == "lower":
+                    lower_fixed_int = _quantize_to_fixed_point_int(
+                        boundary_value, digits, rounding
+                    )
+                if boundary == "upper":
+                    upper_fixed_int = _quantize_to_fixed_point_int(
+                        boundary_value, digits, rounding
+                    )
 
-            dframe.loc[constants, col] = (
-                dframe.loc[constants, col] + sign / 10.0**digits - epsilon
-            )
+        monotone_floatstrings: list[str] = []
+        last_fixed_int: int | None = None
+        for boundary_value in dframe[col].to_numpy():
+            fixed_int = _quantize_to_fixed_point_int(boundary_value, digits, rounding)
 
-            # Ensure nonstrict monotonicity and clips after each modification:
-            dframe[col] = clip_accumulate(dframe[col], spec)
+            if last_fixed_int is not None and fixed_int not in (
+                lower_fixed_int,
+                upper_fixed_int,
+            ):
+                if spec["sign"] == 1:
+                    fixed_int = max(fixed_int, last_fixed_int + 1)
+                    if upper_fixed_int is not None:  # Clamp at upper limit
+                        fixed_int = min(fixed_int, upper_fixed_int)
+                else:
+                    fixed_int = min(fixed_int, last_fixed_int - 1)
+                    if lower_fixed_int is not None:  # Clamp at lower limit
+                        fixed_int = max(fixed_int, lower_fixed_int)
+            last_fixed_int = fixed_int
 
-            # Evaluate what is left to fix:
-            constants = rows_to_be_fixed(dframe[col], spec, digits)
+            monotone_floatstrings.append(_format_fixed_point_int(fixed_int, digits))
 
-        # Warn if more iterations than 5% of the rows
-        # (number of iterations do not necessarily correspond with
-        # number of changed rows)
-        if float(iterations) / float(len(dframe[col])) > 0.05:
-            logger.warning(
-                "Needed %s iterations on column %s of length %s",
-                str(iterations),
-                col,
-                str(len(dframe[col])),
-            )
-
-        # Assert that we have successfully managed to force monotonicity
-        allowance = 1.0 / 10.0**digits
-        if sign > 0:
-            assert not (dframe[col].round(digits).diff() < -allowance).any(), (  # type: ignore[operator]
-                "Not possible to make column monotonically increasing"
-            )
-        else:
-            assert not (dframe[col].round(digits).diff() > allowance).any(), (  # type: ignore[operator]
-                "Not possible to make column monotonically decreasing"
-            )
+        dframe[col] = monotone_floatstrings
     return dframe
 
 
@@ -199,38 +238,6 @@ def check_limits(
         raise ValueError(f"Values larger than upper limit in column {colname}")
     if "lower" in monotonicity and (series < monotonicity["lower"]).any():
         raise ValueError(f"Values smaller than lower limit in column {colname}")
-
-
-def rows_to_be_fixed(
-    series: pd.Series, monotonicity: MonotonicitySpec, digits: int
-) -> pd.Series:
-    """Compute boolean array of rows that must be modified
-
-    Args:
-        series:
-        monotonicity:
-        digits: Accuracy required, how many digits
-            that are to be printed, and to which we should relate
-            constancy to.
-    Returns:
-        boolean series.
-    """
-    if isinstance(series, (list, np.ndarray)):
-        series = pd.Series(series, dtype="float64")
-
-    # minus epsilon is critical to avoid being greedy
-    accuracy = 1.0 / 10.0**digits - epsilon
-    if monotonicity["sign"] > 0:
-        constants = series.round(digits + 1).diff() < accuracy  # type: ignore[operator]
-    else:
-        constants = series.round(digits + 1).diff() > -accuracy  # type: ignore[operator]
-
-    # Allow constants at the lower and upper limits.
-    if "upper" in monotonicity:
-        constants = constants & (series < (monotonicity["upper"] - accuracy))
-    if "lower" in monotonicity:
-        constants = constants & (series > (monotonicity["lower"] + accuracy))
-    return constants
 
 
 def check_almost_monotone(series: pd.Series, digits: int, sign: int) -> None:

--- a/src/pyscal/utils/string.py
+++ b/src/pyscal/utils/string.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 def df2str(
     dframe: pd.DataFrame,
     digits: int = 7,
-    roundlevel: int = 9,
     header: bool = False,
     monotonicity: dict[str, MonotonicitySpec] | None = None,
 ) -> str:
@@ -35,8 +34,6 @@ def df2str(
             It is not recommended to deviate from the default 7 uncritically
             for pyscal output, other code have to be tuned to ensure
             numerical robustness to the deviation.
-        roundlevel: To how many digits should we round prior to print.
-            Recommended to be > digits + 1, see test code.
         header: If the dataframe column header should be included
         monotonicity: Column names in dframe are the keys, pointing
             to a specification for monotonicity to be enforced.
@@ -46,9 +43,7 @@ def df2str(
     if monotonicity is not None:
         dframe = modify_dframe_monotonicity(dframe, monotonicity, digits)
 
-    return dframe.round(roundlevel).to_csv(
-        sep=" ", float_format=float_format, header=header, index=False
-    )
+    return dframe.to_csv(sep=" ", float_format=float_format, header=header, index=False)
 
 
 def comment_formatter(multiline: str, prefix: str = "-- ") -> str:

--- a/tests/test_gasoil.py
+++ b/tests/test_gasoil.py
@@ -577,11 +577,12 @@ def test_roundoff():
     )
     gasoil.table["SGN"] = gasoil.table["SG"]
     gasoil.table["SON"] = 1 - gasoil.table["SG"]
-    # If this value (as string) occurs, then we are victim of floating point truncation
-    # in float_format=".7f":
-    assert "0.1952404" not in gasoil.SGOF()
-    assert "0.1952405" in gasoil.SGOF()
-    check_table(gasoil.table)  # This function allows this monotonicity hiccup.
+    number_lines = [
+        line for line in gasoil.SGOF().splitlines() if line[0] in ("0", "1")
+    ]
+    krog_series: list[str] = [line.split(" ")[2] for line in number_lines]
+    assert len(set(krog_series)) == len(number_lines), "KROG was not strictly monotone"
+    check_table(gasoil.table)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils_monotonicity.py
+++ b/tests/test_utils_monotonicity.py
@@ -1,20 +1,38 @@
 """Test module for monotonicity support functions in pyscal"""
 
-import os
 import math
+import os
+
 import numpy as np
 import pandas as pd
 import pytest
-from hypothesis import strategies as st, given
+from hypothesis import given
+from hypothesis import strategies as st
+
 from pyscal.utils.monotonicity import (
+    _format_fixed_point_int,
+    _quantize_to_fixed_point_int,
     check_almost_monotone,
     check_limits,
     clip_accumulate,
-    modify_dframe_monotonicity,
-    rows_to_be_fixed,
     validate_monotonicity_arg,
 )
 from pyscal.utils.string import df2str
+
+
+@given(st.floats(min_value=-10, max_value=10), st.integers(min_value=1, max_value=10))
+def test_floating_point_formatting_is_identical_to_python_up_to_10_digits(
+    float_value: float, digits: int
+):
+    fixed_point = _quantize_to_fixed_point_int(float_value, digits)
+    python_fmt_string = f"{float_value:.{digits}f}"
+    custom_fmt_string = _format_fixed_point_int(fixed_point, digits)
+    if (
+        custom_fmt_string == "0." + "0" * digits
+        and python_fmt_string == "-0." + "0" * digits
+    ):
+        return
+    assert custom_fmt_string == python_fmt_string
 
 
 @st.composite
@@ -72,7 +90,6 @@ def tricky_almost_monotone_series(draw, max_series_length: int = 100):
     return xs, decimals, sign
 
 
-@pytest.mark.xfail(reason="Monotonicity code has corner-case bugs")
 @given(tricky_almost_monotone_series())
 def test_df2str_yields_strictly_monotone(data):
     values, digits, sign = data
@@ -155,8 +172,7 @@ def test_df2str_monotone():
         (
             [0.02, 0.01, 0.01, 0.00, 0.00],
             {0: {"sign": -1}},
-            ["0.02", "0.01", "-0.00", "-0.01", "-0.02"],
-            #                 ^ this sign is optional, allowed when negative is allowed
+            ["0.02", "0.01", "0.00", "-0.01", "-0.02"],
         ),
         ([1.0, 1.0, 1.0], {0: {"sign": 1, "upper": 1}}, ["1.00", "1.00", "1.00"]),
         ([1, 1, 1], {0: {"sign": 1}}, ["1.00", "1.01", "1.02"]),
@@ -244,7 +260,9 @@ def test_df2str_nonstrict_monotonicity(series, monotonicity, expected):
         (
             [0.00, 0.0002, 0.01, 0.010001, 0.0100001, 0.01, 0.99, 1.0001, 1.00],
             {0: {"sign": 1, "lower": 0, "upper": 1}},
-            ["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "1.0", "1.0", "1.0"],
+            ["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "0.9", "1.0", "1.0"],
+            # Element 6 is rounded down from 0.99 to 0.9 because rounding down
+            # is the correct thing to do for monotone increasing series.
         ),
         (
             [0.2, 0.1, 0.1, 0.0, 0.0],
@@ -254,8 +272,7 @@ def test_df2str_nonstrict_monotonicity(series, monotonicity, expected):
         (
             [0.2, 0.1, 0.1, 0.0, 0.0],
             {0: {"sign": -1}},
-            ["0.2", "0.1", "-0.0", "-0.1", "-0.2"],
-            #               ^ this sign is optional, allowed when negative is allowed
+            ["0.2", "0.1", "0.0", "-0.1", "-0.2"],
         ),
         ([1.0, 1.0, 1.0], {0: {"sign": 1, "upper": 1}}, ["1.0", "1.0", "1.0"]),
         ([1, 1, 1], {0: {"sign": 1}}, ["1.0", "1.1", "1.2"]),
@@ -267,7 +284,7 @@ def test_df2str_nonstrict_monotonicity(series, monotonicity, expected):
         (
             [1, 1, 0.5, 0.01, 0.01, 0, 0],
             {0: {"sign": -1, "lower": 0, "upper": 1}},
-            ["1.0", "1.0", "0.5", "0.0", "0.0", "0.0", "0.0"],
+            ["1.0", "1.0", "0.5", "0.1", "0.0", "0.0", "0.0"],
         ),
         (
             [0, 0, 0.1, 0.1, 0.5, 1, 1],
@@ -290,7 +307,7 @@ def test_df2str_nonstrict_monotonicity(series, monotonicity, expected):
                 "0.0",
                 "0.0",
                 "0.0",
-                "1.0",
+                "0.9",
                 "1.0",
                 "1.0",
                 "1.0",
@@ -390,29 +407,6 @@ def test_check_limits(series, monotonicity, colname, error_str):
 
 
 @pytest.mark.parametrize(
-    "series, monotonicity, digits, expected",
-    [
-        ([], {"sign": 1}, 0, []),
-        ([], {"sign": 1}, 2, []),
-        ([0], {"sign": 1}, 2, [False]),
-        ([0, 0.1], {"sign": 1}, 2, [False, False]),
-        ([0, 0.1], {"sign": 1}, 1, [False, False]),
-        ([0, 0.1], {"sign": 1}, 0, [False, True]),
-        ([0.1, 0], {"sign": -1}, 2, [False, False]),
-        ([0.1, 0], {"sign": -2}, 1, [False, False]),
-        ([0.1, 0], {"sign": -1}, 0, [False, True]),
-        # But this is allowed if at limits:
-        ([0, 0.1], {"sign": 2, "upper": 0.1}, 0, [False, False]),
-        ([0.1, 0], {"sign": -1, "lower": 0}, 0, [False, False]),
-    ],
-)
-def test_rows_to_be_fixed(series, monotonicity, digits, expected):
-    """Check that we can make a boolean array of which elements must be fixed for
-    monotonicity"""
-    assert (rows_to_be_fixed(series, monotonicity, digits) == expected).all()
-
-
-@pytest.mark.parametrize(
     "series, digits, sign, expected_error",
     [
         ([], 0, 1, None),
@@ -471,12 +465,3 @@ def test_validate_monotonicity_arg(monotonicity, dframe_colnames, error_str):
         assert error_str in str(err)
     else:
         validate_monotonicity_arg(monotonicity, dframe_colnames)
-
-
-def test_modify_dframe_monotonicity_many_iterations():
-    """This dataframe should be the worst kind scenario (?) in terms of how many
-    iterations are needed. This gives len(dframe) - 1 iterations, and the code
-    would bail (AssertionError) if we get to 2*len(dframe) iterations."""
-    modify_dframe_monotonicity(
-        pd.DataFrame({"SW": [0.1, 0.1, 0.1, 0.09]}), {"SW": {"sign": -1}}, 2
-    )

--- a/tests/test_utils_monotonicity.py
+++ b/tests/test_utils_monotonicity.py
@@ -1,11 +1,11 @@
 """Test module for monotonicity support functions in pyscal"""
 
 import os
-
+import math
 import numpy as np
 import pandas as pd
 import pytest
-
+from hypothesis import strategies as st, given
 from pyscal.utils.monotonicity import (
     check_almost_monotone,
     check_limits,
@@ -15,6 +15,73 @@ from pyscal.utils.monotonicity import (
     validate_monotonicity_arg,
 )
 from pyscal.utils.string import df2str
+
+
+@st.composite
+def tricky_almost_monotone_series(draw, max_series_length: int = 100):
+    """
+    Generate a series that is intended to be strictly increasing in real numbers,
+    but has values concentrated around decimal rounding boundaries and includes
+    negatives.
+
+    Construction:
+      base_k is an integer tick index on a decimal grid (10^-d)
+      value is (base_k + offset) / 10^d
+    where offset is near +/- 0.5 tick (ties) plus tiny noise.
+    """
+    decimals: int = draw(st.integers(min_value=1, max_value=16))
+    series_length: int = draw(st.integers(min_value=2, max_value=max_series_length))
+    sign = draw(st.sampled_from([-1, 1]))
+
+    scale: int = 10**decimals
+
+    # Start somewhere near 0 in scaled-int space, allow negative region too.
+    start_k = draw(st.integers(min_value=-5 * scale, max_value=5 * scale))
+
+    # Strictly increasing or decreasing tick indices, but sometimes by only 1 tick.
+    steps = draw(
+        st.lists(
+            st.integers(min_value=1, max_value=3),
+            min_size=series_length,
+            max_size=series_length,
+        )
+    )
+    ks = []
+    k = start_k
+    for step in steps:
+        k += sign * step
+        ks.append(k)
+
+    # Offsets chosen to create "hard" rounding cases:
+    # near half-tick, plus tiny signed noise.
+    offsets = []
+    for _ in range(series_length):
+        center = draw(st.sampled_from([-0.5, 0.0, 0.5]))
+        noise = draw(
+            st.floats(
+                min_value=-1e-12, max_value=1e-12, allow_nan=False, allow_infinity=False
+            )
+        )
+        offsets.append(center + noise)
+
+    xs = [(k + off) / scale for k, off in zip(ks, offsets)]
+
+    # ensure all are finite
+    assert all(math.isfinite(x) for x in xs)
+
+    return xs, decimals, sign
+
+
+@pytest.mark.xfail(reason="Monotonicity code has corner-case bugs")
+@given(tricky_almost_monotone_series())
+def test_df2str_yields_strictly_monotone(data):
+    values, digits, sign = data
+    str_table = df2str(
+        pd.DataFrame(data=values), digits=digits, monotonicity={0: {"sign": sign}}
+    )
+    assert len(set(str_table.strip().split("\n"))) == len(values), (
+        "Printed numbers were not strictly monotone"
+    )
 
 
 def test_df2str_monotone():

--- a/tests/test_utils_string.py
+++ b/tests/test_utils_string.py
@@ -13,56 +13,15 @@ def test_df2str():
     # Easy cases:
     assert df2str(pd.DataFrame(data=[0.1]), digits=1).strip() == "0.1"
     assert df2str(pd.DataFrame(data=[0.1]), digits=3).strip() == "0.100"
-    assert df2str(pd.DataFrame(data=[0.1]), digits=3, roundlevel=3).strip() == "0.100"
-    assert df2str(pd.DataFrame(data=[0.1]), digits=3, roundlevel=4).strip() == "0.100"
-    assert df2str(pd.DataFrame(data=[0.1]), digits=3, roundlevel=5).strip() == "0.100"
-    assert df2str(pd.DataFrame(data=[0.01]), digits=3, roundlevel=2).strip() == "0.010"
-
-    # Here roundlevel will ruin the result:
-    assert df2str(pd.DataFrame(data=[0.01]), digits=3, roundlevel=1).strip() == "0.000"
+    assert df2str(pd.DataFrame(data=[0.01]), digits=3).strip() == "0.010"
 
     # Tricky ones:
     # This one should be rounded down:
     assert df2str(pd.DataFrame(data=[0.0034999]), digits=3).strip() == "0.003"
-    # But if we are on the 9999 side due to representation error, the
-    # number probably represents 0.0035 so it should be rounded up
-    assert (
-        df2str(pd.DataFrame(data=[0.003499999999998]), digits=3, roundlevel=5).strip()
-        == "0.004"
-    )
-    # If we round to more digits than we have in IEE754, we end up truncating:
-    assert (
-        df2str(pd.DataFrame(data=[0.003499999999998]), digits=3, roundlevel=20).strip()
-        == "0.003"  # "Wrong" due to IEE754 truncation.
-    )
-    # If we round straight to out output, we are not getting the chance to correct for
-    # the representation error:
-    assert (
-        df2str(pd.DataFrame(data=[0.003499999999998]), digits=3, roundlevel=3).strip()
-        == "0.003"  # Wrong
-    )
-    # So roundlevel > digits
-    assert (
-        df2str(pd.DataFrame(data=[0.003499999999998]), digits=3, roundlevel=4).strip()
-        == "0.004"
-    )
-    # But digits < roundlevel < 15 works:
-    assert (
-        df2str(pd.DataFrame(data=[0.003499999999998]), digits=3, roundlevel=14).strip()
-        == "0.004"
-    )
-    assert (
-        df2str(pd.DataFrame(data=[0.003499999999998]), digits=3, roundlevel=15).strip()
-        == "0.003"  # Wrong
-    )
 
-    # Double rounding is a potential issue, as:
-    assert round(0.0034445, 5) == 0.00344
-    assert round(round(0.0034445, 6), 5) == 0.00345  # Wrong
-    # So if pd.to_csv would later round instead of truncate, we could be victim
-    # of this, having roundlevel >  digits + 1 would avoid that:
-    assert round(round(0.0034445, 7), 5) == 0.00344
-    # (this is the rationale for roundlevel > digits + 1)
+    # This number would be 0.0035 in IEE754 and would then be rounded up,
+    # but the rounding and string production do not depend on IEE754:
+    assert df2str(pd.DataFrame(data=[0.003499999999998]), digits=3).strip() == "0.003"
 
 
 def test_comment_formatter():


### PR DESCRIPTION
Monotonicity enforcement code and float-to-string conversion code has been reworked and merged.

Numerical values were previously modified for monotonocity in IEE754-space, and then printed using `float_format` to the specified number of digits in `pd.to_csv`. In corner cases, this is not sufficient and could lead to series being strictly monotone when measured as IEE754, but end up printed as only monotone.

In this revised code, strict monotonocity is enforced in integer space, and string production is done from this same integer space.