### PR TITLE
Prioritize kroend over krowend/krogend

### DIFF
--- a/docs/make_plots.py
+++ b/docs/make_plots.py
@@ -450,8 +450,8 @@ def make_gasoil_condensate_cid2(show: bool = True) -> None:
     sorg = 0.15
     krgend = 1
     krgmax = 1
-    krowend = 0.8
     krogend = 0.8
+    kroend = krogend
     kromax = 1
     krgendanchor = ""
     nw = 2
@@ -464,8 +464,9 @@ def make_gasoil_condensate_cid2(show: bool = True) -> None:
             "now": now,
             "ng": ng,
             "nog": nog,
-            "krowend": krowend,
-            "krogend": krogend,
+            # "krowend": krowend,
+            # "krogend": krogend,
+            "kroend": kroend,
             "kromax": kromax,
             "krgend": krgend,
             "krgmax": krgmax,
@@ -562,6 +563,7 @@ def make_wateroil_condensate_idc2(show: bool = True) -> None:
     krwend = 0.8
     krwmax = 1
     krowend = 0.85
+    kroend = krowend
     kromax = 1
     nw = 4
     now = 1.8
@@ -573,7 +575,7 @@ def make_wateroil_condensate_idc2(show: bool = True) -> None:
             "now": now,
             "ng": ng,
             "nog": nog,
-            "krowend": krowend,
+            "kroend": kroend,
             "kromax": kromax,
             "krwend": krwend,
             "swl": swl,

--- a/docs/make_plots.py
+++ b/docs/make_plots.py
@@ -464,8 +464,6 @@ def make_gasoil_condensate_cid2(show: bool = True) -> None:
             "now": now,
             "ng": ng,
             "nog": nog,
-            # "krowend": krowend,
-            # "krogend": krogend,
             "kroend": kroend,
             "kromax": kromax,
             "krgend": krgend,

--- a/src/pyscal/factory.py
+++ b/src/pyscal/factory.py
@@ -1437,19 +1437,15 @@ def kro_endpoint_wo(params: dict[str, Any]) -> dict[str, Any]:
     """
     params_copy = params.copy()
 
-    if "krowend" in params_copy:
-        if "kroend" in params_copy:
-            logger.warning(
-                "Both 'krowend'=%r and 'kroend'=%r were provided; using the "
-                "'kroend' value for WaterOil construction.",
-                params_copy["krowend"],
-                params_copy["kroend"],
-            )
-            # Overwrite any existing 'krowend' with the 'kroend' value
-            params_copy["krowend"] = params_copy["kroend"]
-        else:
-            # Rename 'krowend' to 'kroend'
-            params_copy["kroend"] = params_copy["krowend"]
+    if "krowend" in params_copy and "kroend" in params_copy:
+        logger.warning(
+            "Both 'krowend'=%r and 'kroend'=%r were provided; using the "
+            "'kroend' value for WaterOil construction.",
+            params_copy["krowend"],
+            params_copy["kroend"],
+        )
+        # Overwrite any existing 'krowend' with the 'kroend' value
+        params_copy["krowend"] = params_copy["kroend"]
 
     # Remove GasOil key if it sneaks in
     params_copy.pop("krogend", None)
@@ -1473,19 +1469,15 @@ def kro_endpoint_go(params: dict[str, Any]) -> dict[str, Any]:
     """
     params_copy = params.copy()
 
-    if "krogend" in params_copy:
-        if "kroend" in params_copy:
-            logger.warning(
-                "Both 'krogend'=%r and 'kroend'=%r were provided; using the "
-                "'kroend' value for GasOil construction.",
-                params_copy["krogend"],
-                params_copy["kroend"],
-            )
-            # Overwrite any existing 'krogend' with the 'kroend' value
-            params_copy["krogend"] = params_copy["kroend"]
-        else:
-            # Rename 'krogend' to 'kroend'
-            params_copy["kroend"] = params_copy["krogend"]
+    if "krogend" in params_copy and "kroend" in params_copy:
+        logger.warning(
+            "Both 'krogend'=%r and 'kroend'=%r were provided; using the "
+            "'kroend' value for GasOil construction.",
+            params_copy["krogend"],
+            params_copy["kroend"],
+        )
+        # Overwrite any existing 'krogend' with the 'kroend' value
+        params_copy["krogend"] = params_copy["kroend"]
 
     # Remove WaterOil key if it sneaks in
     params_copy.pop("krowend", None)

--- a/src/pyscal/factory.py
+++ b/src/pyscal/factory.py
@@ -1441,12 +1441,15 @@ def kro_endpoint_wo(params: dict[str, Any]) -> dict[str, Any]:
         if "kroend" in params_copy:
             logger.warning(
                 "Both 'krowend'=%r and 'kroend'=%r were provided; using the "
-                "'krowend' value for WaterOil construction.",
+                "'kroend' value for WaterOil construction.",
                 params_copy["krowend"],
                 params_copy["kroend"],
             )
-        # Overwrite any existing 'kroend' with the 'krowend' value, then drop 'krowend'
-        params_copy["kroend"] = params_copy.pop("krowend")
+            # Overwrite any existing 'krowend' with the 'kroend' value
+            params_copy["krowend"] = params_copy["kroend"]
+        else:
+            # Rename 'krowend' to 'kroend'
+            params_copy["kroend"] = params_copy["krowend"]
 
     # Remove GasOil key if it sneaks in
     params_copy.pop("krogend", None)
@@ -1474,12 +1477,15 @@ def kro_endpoint_go(params: dict[str, Any]) -> dict[str, Any]:
         if "kroend" in params_copy:
             logger.warning(
                 "Both 'krogend'=%r and 'kroend'=%r were provided; using the "
-                "'krogend' value for GasOil construction.",
+                "'kroend' value for GasOil construction.",
                 params_copy["krogend"],
                 params_copy["kroend"],
             )
-        # Overwrite any existing 'kroend' with the 'krowend' value, then drop 'krowend'
-        params_copy["kroend"] = params_copy.pop("krogend")
+            # Overwrite any existing 'krogend' with the 'kroend' value
+            params_copy["krogend"] = params_copy["kroend"]
+        else:
+            # Rename 'krogend' to 'kroend'
+            params_copy["kroend"] = params_copy["krogend"]
 
     # Remove WaterOil key if it sneaks in
     params_copy.pop("krowend", None)

--- a/src/pyscal/factory.py
+++ b/src/pyscal/factory.py
@@ -1425,7 +1425,7 @@ def kro_endpoint_wo(params: dict[str, Any]) -> dict[str, Any]:
     """
     Normalize parameters to be used for creating a WaterOil object:
     - If 'krowend' is present, rename it to 'kroend'.
-    - If both 'krowend' and 'kroend' are provided, use the 'krowend' value
+    - If both 'krowend' and 'kroend' are provided, use the 'kroend' value
       and log a warning.
     - Always remove 'krogend' if present (not relevant for WaterOil).
 
@@ -1457,7 +1457,7 @@ def kro_endpoint_go(params: dict[str, Any]) -> dict[str, Any]:
     """
     Normalize parameters to be used for creating a GasOil object:
     - If 'krogend' is present, rename it to 'kroend'.
-    - If both 'krogend' and 'kroend' are provided, use the 'krogend' value
+    - If both 'krogend' and 'kroend' are provided, use the 'kroend' value
       and log a warning.
     - Always remove 'krowend' if present (not relevant for GasOil).
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -688,10 +688,10 @@ def test_factory_wateroilgas_krowgend():
     sat_table_str_ok(sgof)
     assert "Corey krg" in sgof
     assert "Corey krog" in sgof
-    assert "kroend=0.7" in sgof
+    assert "kroend=0.5" in sgof
     assert "Corey krw" in swof
     assert "Corey krow" in swof
-    assert "kroend=0.6" in swof
+    assert "kroend=0.5" in swof
     assert "krogend" not in swof
     assert "krowend" not in sgof
 
@@ -717,12 +717,12 @@ def test_factory_wateroilgas_warning(caplog):
         )
         assert (
             "Both 'krowend'=0.6 and 'kroend'=0.5 were provided; "
-            "using the 'krowend' value for WaterOil construction."
+            "using the 'kroend' value for WaterOil construction."
         ) in caplog.text
 
         assert (
             "Both 'krogend'=0.7 and 'kroend'=0.5 were provided; "
-            "using the 'krogend' value for GasOil construction."
+            "using the 'kroend' value for GasOil construction."
         ) in caplog.text
 
 


### PR DESCRIPTION
This will PR will revert the previous behavior prior to 02ed1af5a

When user specify both krowend and kroend, it will use kroend.
When user specify both krogend and kroend, it will use kroend.
