### PR TITLE
Prioritize kroend over krowend/krogend

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -201,9 +201,18 @@ users when input is written in a different context, like an Excel
 spreadsheet.
 
 Also bear in mind that some API parameter names are ambiguous in the context of
-the factory. ``kroend`` makes sense for ``WaterOil.add_corey_oil()`` but
-is ambiguous in the factory where both water-oil and gas-oil are accounted for.
-In the factory the names ``krowend`` and ``krogend`` must be used.
+the factory and type of a modelled system.
+For wet gas/condensate modelling (ICD2/CID2/IDC2), the intended inputs are the
+phase-specific endpoints: use ``krowend`` for the water-oil branch and
+``krogend`` for the gas-oil branch. This keeps the phase meaning explicit and
+aligns with the condensate workflow described in the modelling section.
+Outside wet gas/condensate modelling, ``kroend`` is the normal and unambiguous
+endpoint key. In those cases where ``kroend = krowend = krogend``, using
+``kroend`` is sufficient. ``kroend`` is unambiguous and applies
+directly to the oil branch methods for phase-pair specific classes such as
+``WaterOil.add_corey_oil()`` and ``GasOil.add_corey_oil()``.
+In short: use phase-specific keys when modelling wet gas/condensate behavior;
+otherwise use ``kroend``.
 
 Similarly for the LET parameters, where `l` is valid for the low-level
 functions, while in the factory context you must state `Lo`, `Lw`, `Lg` or `Log`

--- a/src/pyscal/factory.py
+++ b/src/pyscal/factory.py
@@ -1424,9 +1424,11 @@ def check_deprecated(params: dict[str, Any]) -> None:
 def kro_endpoint_wo(params: dict[str, Any]) -> dict[str, Any]:
     """
     Normalize parameters to be used for creating a WaterOil object:
-    - If 'krowend' is present, rename it to 'kroend'.
-    - If both 'krowend' and 'kroend' are provided, use the 'krowend' value
-      and log a warning.
+    - If only 'krowend' is present and not NaN, map it to 'kroend'.
+    - If both 'krowend' and 'kroend' are present, treat NaN as missing for
+    endpoint selection; when both are valid, legacy 'kroend' is prioritized.
+    - Log a warning only when both are present and both are not NaN.
+    - Always remove 'krowend'.
     - Always remove 'krogend' if present (not relevant for WaterOil).
 
     Args:
@@ -1438,17 +1440,28 @@ def kro_endpoint_wo(params: dict[str, Any]) -> dict[str, Any]:
     params_copy = params.copy()
 
     if "krowend" in params_copy:
+        krowend = params_copy["krowend"]
+        krowend_valid = not pd.isna(krowend)
         if "kroend" in params_copy:
-            logger.warning(
-                "Both 'krowend'=%r and 'kroend'=%r were provided; using the "
-                "'krowend' value for WaterOil construction.",
-                params_copy["krowend"],
-                params_copy["kroend"],
-            )
-        # Overwrite any existing 'kroend' with the 'krowend' value, then drop 'krowend'
-        params_copy["kroend"] = params_copy.pop("krowend")
+            kroend = params_copy["kroend"]
+            kroend_valid = not pd.isna(kroend)
 
-    # Remove GasOil key if it sneaks in
+            if kroend_valid and krowend_valid:
+                logger.warning(
+                    "Both 'krowend'=%r and 'kroend'=%r were provided; using the "
+                    "'kroend' value for WaterOil construction.",
+                    krowend,
+                    kroend,
+                )
+            elif not kroend_valid and krowend_valid:
+                params_copy["kroend"] = krowend
+        elif krowend_valid:
+            # Rename 'krowend' to 'kroend'
+            params_copy["kroend"] = krowend
+
+        # Drop 'krowend' to avoid confusion
+        params_copy.pop("krowend", None)
+
     params_copy.pop("krogend", None)
 
     return params_copy
@@ -1457,9 +1470,11 @@ def kro_endpoint_wo(params: dict[str, Any]) -> dict[str, Any]:
 def kro_endpoint_go(params: dict[str, Any]) -> dict[str, Any]:
     """
     Normalize parameters to be used for creating a GasOil object:
-    - If 'krogend' is present, rename it to 'kroend'.
-    - If both 'krogend' and 'kroend' are provided, use the 'krogend' value
-      and log a warning.
+    - If only 'krogend' is present and not NaN, map it to 'kroend'.
+    - If both 'krogend' and 'kroend' are present, treat NaN as missing for
+    endpoint selection; when both are valid, legacy 'kroend' is prioritized.
+    - Log a warning only when both are present and both are not NaN.
+    - Always remove 'krogend'.
     - Always remove 'krowend' if present (not relevant for GasOil).
 
     Args:
@@ -1471,17 +1486,28 @@ def kro_endpoint_go(params: dict[str, Any]) -> dict[str, Any]:
     params_copy = params.copy()
 
     if "krogend" in params_copy:
+        krogend = params_copy["krogend"]
+        krogend_valid = not pd.isna(krogend)
         if "kroend" in params_copy:
-            logger.warning(
-                "Both 'krogend'=%r and 'kroend'=%r were provided; using the "
-                "'krogend' value for GasOil construction.",
-                params_copy["krogend"],
-                params_copy["kroend"],
-            )
-        # Overwrite any existing 'kroend' with the 'krowend' value, then drop 'krowend'
-        params_copy["kroend"] = params_copy.pop("krogend")
+            kroend = params_copy["kroend"]
+            kroend_valid = not pd.isna(kroend)
 
-    # Remove WaterOil key if it sneaks in
+            if kroend_valid and krogend_valid:
+                logger.warning(
+                    "Both 'krogend'=%r and 'kroend'=%r were provided; using the "
+                    "'kroend' value for GasOil construction.",
+                    krogend,
+                    kroend,
+                )
+            elif not kroend_valid and krogend_valid:
+                params_copy["kroend"] = krogend
+        elif krogend_valid:
+            # Rename 'krogend' to 'kroend'
+            params_copy["kroend"] = krogend
+
+        # Drop 'krogend' to avoid confusion
+        params_copy.pop("krogend", None)
+
     params_copy.pop("krowend", None)
 
     return params_copy

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -663,12 +663,46 @@ def test_factory_wateroilgas_krowgend():
     """
     Test normalize krowend and krogend to kroend and put into
     create_water_oil and create_oil_gas, respectively
-    Normalize WaterOil parameters to be used for creating a
-    WaterOil(look into swof) object:
     - If 'krowend' is present, rename it to 'kroend'.
-    - If both 'krowend' and 'kroend' are provided, use the 'krowend' value
-      and log a warning.
-    - Always remove 'krogend' if present (not relevant for WaterOil).
+    - If 'krogend' is present, rename it to 'kroend'.
+    - Always remove 'krowend' and 'krogend' if present
+    (not relevant for WaterOil/GasOil).
+    """
+
+    wog = create_water_oil_gas(
+        {
+            "nw": 2,
+            "now": 3,
+            "ng": 1,
+            "nog": 2.5,
+            "krowend": 0.6,
+            "krogend": 0.7,
+        }
+    )
+    swof = wog.SWOF()
+    sgof = wog.SGOF()
+    sat_table_str_ok(swof)
+    sat_table_str_ok(sgof)
+    assert "Corey krg" in sgof
+    assert "Corey krog" in sgof
+    assert "kroend=0.7" in sgof
+    assert "Corey krw" in swof
+    assert "Corey krow" in swof
+    assert "kroend=0.6" in swof
+    assert "krowend" not in swof
+    assert "krogend" not in swof
+    assert "krogend" not in sgof
+    assert "krowend" not in sgof
+
+    check_table(wog.gasoil.table)
+    check_table(wog.wateroil.table)
+
+
+def test_factory_swap_krowgend():
+    """
+    Test prioritize kroend over krowend and krogend.
+    Always remove 'krowend' and 'krogend' if present
+    (not relevant for WaterOil/GasOil).
     """
 
     wog = create_water_oil_gas(
@@ -688,11 +722,13 @@ def test_factory_wateroilgas_krowgend():
     sat_table_str_ok(sgof)
     assert "Corey krg" in sgof
     assert "Corey krog" in sgof
-    assert "kroend=0.7" in sgof
+    assert "kroend=0.5" in sgof
     assert "Corey krw" in swof
     assert "Corey krow" in swof
-    assert "kroend=0.6" in swof
+    assert "kroend=0.5" in swof
+    assert "krowend" not in swof
     assert "krogend" not in swof
+    assert "krogend" not in sgof
     assert "krowend" not in sgof
 
     check_table(wog.gasoil.table)
@@ -717,13 +753,73 @@ def test_factory_wateroilgas_warning(caplog):
         )
         assert (
             "Both 'krowend'=0.6 and 'kroend'=0.5 were provided; "
-            "using the 'krowend' value for WaterOil construction."
+            "using the 'kroend' value for WaterOil construction."
         ) in caplog.text
 
         assert (
             "Both 'krogend'=0.7 and 'kroend'=0.5 were provided; "
-            "using the 'krogend' value for GasOil construction."
+            "using the 'kroend' value for GasOil construction."
         ) in caplog.text
+
+
+def test_factory_wateroilgas_nan_kroend(caplog):
+    """If kroend is NaN, valid phase-specific keys should be used without warning."""
+    with caplog.at_level(logging.WARNING):
+        wog = create_water_oil_gas(
+            {
+                "nw": 2,
+                "now": 3,
+                "ng": 1,
+                "nog": 2.5,
+                "krowend": 0.6,
+                "krogend": 0.7,
+                "kroend": np.nan,
+            }
+        )
+
+    swof = wog.SWOF()
+    sgof = wog.SGOF()
+    sat_table_str_ok(swof)
+    sat_table_str_ok(sgof)
+
+    assert "kroend=0.6" in swof
+    assert "kroend=0.7" in sgof
+    assert "krowend" not in swof
+    assert "krogend" not in swof
+    assert "krowend" not in sgof
+    assert "krogend" not in sgof
+    assert "Both 'krowend'" not in caplog.text
+    assert "Both 'krogend'" not in caplog.text
+
+
+def test_factory_wateroilgas_nan_legacy_keeps_valid_kroend(caplog):
+    """If phase-specific keys are NaN, valid kroend should be kept without warning."""
+    with caplog.at_level(logging.WARNING):
+        wog = create_water_oil_gas(
+            {
+                "nw": 2,
+                "now": 3,
+                "ng": 1,
+                "nog": 2.5,
+                "krowend": np.nan,
+                "krogend": np.nan,
+                "kroend": 0.5,
+            }
+        )
+
+    swof = wog.SWOF()
+    sgof = wog.SGOF()
+    sat_table_str_ok(swof)
+    sat_table_str_ok(sgof)
+
+    assert "kroend=0.5" in swof
+    assert "kroend=0.5" in sgof
+    assert "krowend" not in swof
+    assert "krogend" not in swof
+    assert "krowend" not in sgof
+    assert "krogend" not in sgof
+    assert "Both 'krowend'" not in caplog.text
+    assert "Both 'krogend'" not in caplog.text
 
 
 def test_factory_wateroilgas_wo():


### PR DESCRIPTION
This PR modifies the functionality introduced in https://github.com/equinor/pyscal/pull/471 to prioritize `kroend` (legacy) over `krowend`/`krogend`. This is in relation to a condensate system.

**Background**
PR #471 introduced support for phase-specific endpoint keys ( `krowend` for WaterOil and `krogend` for GasOil).
Some existing workflows still provide `kroend`, and rely on it being used when multiple endpoint keys are present.

**PR Changes**
- Keep support for phase-specific keys `krowend`, `krogend`
- Prioritizes `kroend` when it is present together with the phase-specific keys
  - If `kroend` contains a valid value, it is used (highest priority).
  - If `kroend` is missing or contains NaN, `kroend` is treated as unavailable and the implementation falls back to the phase-specific endpoints:
    - `krowend` maps to WaterOil kroend.
    - `krogend` maps to GasOil kroend.

This ensures correct behavior for the edge case where `kroend` is present in the input but its value is NaN.

- Emits warnings when multiple endpoint keys are provided with non-NaN values to encourage migration toward the phase-specific keys (`krowend`/`krogend`).
- Updates/adds tests to verify:
    - priority order of input keys
    - warning behavior
    - normalization behavior
    - NaN-aware endpoint handling:
       -fallback to phase-specific keys when `kroend` is NaN
       -keep `kroend` when phase-specific keys are NaN
       -no warning when one side is NaN
       -phase-specific keys are removed from output representations


**Behavior**
- If `kroend` is present: it is used (highest priority).
- If `kroend` is absent:
    - `krowend` maps to WaterOil kroend.
    - `krogend` maps to GasOil kroend.
    - NaN is treated as missing for endpoint selection.
    - Irrelevant phase key is removed per phase during normalization.
- Warning is only logged when both legacy and canonical values are present and non-NaN.

**Backward Compatibility**
- Existing inputs using `kroend` continue to work as expected.
- Existing mixed-input cases now consistently favor legacy `kroend`.
- Users are informed via warnings when legacy input is detected.
