### PR TITLE
Adopt pre-commit to pin lint tooling versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  # Keeps pinned pre-commit hooks (ruff, rstcheck) up to date. Dependabot opens
+  # a PR when a hook's rev has a new release, and CI runs on that PR.
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pyscal.yml
+++ b/.github/workflows/pyscal.yml
@@ -83,15 +83,10 @@ jobs:
         if: ${{ always() }}
         run: uv pip freeze
 
-      - name: Ruff check
+      - name: Linting using pre-commit
         if: ${{ always() }}
         run: |
-          ruff check .
-
-      - name: Ruff format
-        if: ${{ always() }}
-        run: |
-          ruff format . --check
+          pre-commit run --all-files --show-diff-on-failure
 
       - name: Check typing with mypy
         if: ${{ always() }}
@@ -103,11 +98,6 @@ jobs:
         run: |
           python -c "import pyscal"
           pytest -n auto --strict-markers --hypothesis-profile ci tests/
-
-      - name: Syntax check documentation
-        if: ${{ always() }}
-        run: |
-          rstcheck -r docs
 
       - name: Install font (xkcd) for documentation
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == env.DEFAULT_PYTHON_VERSION }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# The ruff version below is the single source of truth for linting/formatting.
+# CI runs these same hooks, so local and CI ruff versions can never diverge.
+# Bump the rev here (e.g. via `pre-commit autoupdate`) to upgrade ruff.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.0
+    hooks:
+      - id: ruff-check
+      - id: ruff-format
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.2.5
+    hooks:
+      - id: rstcheck
+        # Scope to docs/ to match the previous CI `rstcheck -r docs`.
+        files: ^docs/.*\.rst$
+        # sphinx is needed so sphinx-specific roles/directives (e.g. :func:)
+        # resolve; matches the docs extra's `sphinx < 9` pin.
+        additional_dependencies: ["sphinx<9"]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -33,6 +33,7 @@ Create pull request
         source ~/venv/pyscal/bin/activate
         pip install -U pip
         pip install -e ".[tests,docs]"
+        pre-commit install
   
 4. Run the tests to ensure everything works:
 
@@ -49,12 +50,12 @@ Create pull request
 Now you can make your changes locally.
 
 6. When you're done making changes, check that your changes pass ruff, mypy and the
-   tests:
+   tests. Ruff runs automatically on ``git commit`` via pre-commit, or run it
+   manually with:
 
   .. code-block:: bash
-  
-        ruff check .
-        ruff format .
+
+        pre-commit run --all-files
         mypy src/pyscal
         pytest -n auto
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,13 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
-    "ruff",
+    "pre-commit",
     "mypy",
     "hypothesis",
     "pytest",
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist",
-    "rstcheck",
     "pandas-stubs",
     "scipy-stubs",
 ]
@@ -121,6 +120,7 @@ ignore = [
     "PLR0911",  # Too many return statements
     "PLR0912",  # Too many branches
     "PLR0913",  # Too many arguments
+    "PLR0917",  # Too many positional arguments
     "PLR0915",  # Too many statements
 ]
 


### PR DESCRIPTION
Run ruff and rstcheck via pre-commit so the pinned versions are the single source of truth for both local dev and CI. This
stops ruff releases from breaking CI on unrelated PRs; upgrades now land as reviewable rev bumps.

- Move ruff and rstcheck to .pre-commit-config.yaml; CI runs `pre-commit run --all-files`
- Drop ruff and rstcheck from pyproject test deps (versions now pinned in pre-commit only)
- Add Dependabot pre-commit ecosystem to bump hooks weekly
- Ignore ruff PLR0917; we already ignore its sibiling PLR0913